### PR TITLE
Remove the Labs label

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # loopback-swagger
 
-![StrongLoop Labs](http://docs.strongloop.com/download/thumbnails/5310165/StrongLoop%20Labs%20Logo%20Cropped.png "StrongLoop Labs")
+Utilities to transform between Swagger API specs and LoopBack remoting metadata.
 
-> StrongLoop Labs projects provide early access to advanced or experimental functionality.  In general, these projects may lack usability, completeness, documentation, and robustness, and may be outdated.
-However, StrongLoop supports these projects: Paying customers can open issues using the StrongLoop customer support system (Zendesk), and community users can report bugs on GitHub.
+This is an internal module used by the following user-facing tools:
 
-Utilities to transform between Swagger API specs and LoopBack remoting metadata. 
-
+ - [slc loopback:swagger](https://docs.strongloop.com/display/LB/Swagger+generator)


### PR DESCRIPTION
We are about to move swagger-spec generator from loopback-explorer to loopback-swagger. Because loopback-explorer is a regular (fully supported) module, we need to remove loopback-swagger from the Labs mode first.

/to @raymondfeng please review
/cc @crandmck 