### PR TITLE
specgen: ensure operation ids are unique

### DIFF
--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -23,15 +23,20 @@ var routeHelper = module.exports = {
    * `returns` declarations need some basic conversions to be compatible.
    *
    * This method will convert the route and add it to the doc.
+   *
    * @param  {Route} route    Strong Remoting Route object.
    * @param  {Class} classDef Strong Remoting class.
    * @param  {TypeRegistry} typeRegistry Registry of types and models.
+   * @param  {Object} operationIdRegistry Registry of operationIds mapping
+   *  operationId to an operation object.
    * @param  {Object} paths   Swagger Path Object,
    *   see https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#pathsObject
    */
-  addRouteToSwaggerPaths: function(route, classDef, typeRegistry, paths) {
+  addRouteToSwaggerPaths: function(route, classDef, typeRegistry,
+                                   operationIdRegistry, paths) {
     var entryToAdd = routeHelper.routeToPathEntry(route, classDef,
-                                                  typeRegistry);
+                                                  typeRegistry,
+                                                  operationIdRegistry);
     if (!(entryToAdd.path in paths)) {
       paths[entryToAdd.path] = {};
     }
@@ -111,7 +116,8 @@ var routeHelper = module.exports = {
    * Swagger-formatted "Path Item Object"
    * See swagger-spec/2.0.md#pathItemObject
    */
-  routeToPathEntry: function(route, classDef, typeRegistry) {
+  routeToPathEntry: function(route, classDef,
+                             typeRegistry, operationIdRegistry) {
     // Some parameters need to be altered; eventually most of this should
     // be removed.
     var accepts = routeHelper.convertAcceptsToSwagger(route, classDef,
@@ -142,22 +148,24 @@ var routeHelper = module.exports = {
 
     debug('route %j', route);
 
+    var path = routeHelper.convertPathFragments(route.path);
+    var verb = routeHelper.convertVerb(route.verb);
+
     var tags = [];
     if (classDef && classDef.name) {
       tags.push(classDef.name);
     }
 
+    var operationId = createUniqueOperationId(route.method, verb, path,
+                                              operationIdRegistry);
     var entry = {
-      path: routeHelper.convertPathFragments(route.path),
-      method: routeHelper.convertVerb(route.verb),
+      path: path,
+      method: verb,
       operation: {
         tags: tags,
         summary: typeConverter.convertText(route.description),
         description: typeConverter.convertText(route.notes),
-        // [bajtos] We used to remove leading model name from the operation
-        // name for Swagger Spec 1.2. Swagger Spec 2.0 requires
-        // operation ids to be unique, thus we have to include the model name.
-        operationId: route.method,
+        operationId: operationId,
         // [bajtos] we are omitting consumes and produces, as they are same
         // for all methods and they are already specified in top-level fields
         parameters: accepts,
@@ -166,6 +174,8 @@ var routeHelper = module.exports = {
         // TODO: security
       }
     };
+
+    operationIdRegistry[operationId] = entry;
 
     return entry;
   },
@@ -250,3 +260,39 @@ var routeHelper = module.exports = {
     };
   },
 };
+
+function createUniqueOperationId(methodName, verb, path, operationIdRegistry) {
+  // [bajtos] We used to remove leading model name from the operation
+  // name for Swagger Spec 1.2. Swagger Spec 2.0 requires
+  // operation ids to be unique, thus we have to include the model name.
+  var id = methodName;
+
+  if (!(id in operationIdRegistry)) {
+    // The id is already unique
+    return id;
+  }
+
+  var baseId = id;
+  id = createLongOperationId(baseId, verb, path);
+  if (id in operationIdRegistry) {
+    console.warn('Warning: detected multiple remote methods ' +
+                 'at the same HTTP endpoint. ' +
+                 'Swagger operation ids will be NOT unique.');
+  }
+
+  // Rename the first operation so that all operation ids of
+  // a multi-endpoint method are consistently using the long form
+  if (operationIdRegistry[baseId]) {
+    var oldEntry = operationIdRegistry[baseId];
+    var newId = createLongOperationId(baseId, oldEntry.method, oldEntry.path);
+    oldEntry.operation.operationId = newId;
+    operationIdRegistry[newId] = oldEntry;
+    operationIdRegistry[baseId] = null;
+  }
+
+  return id;
+}
+
+function createLongOperationId(baseId, verb, path) {
+  return baseId + '__' + verb + path.replace(/[\/:]+/g, '_');
+}

--- a/lib/specgen/swagger-spec-generator.js
+++ b/lib/specgen/swagger-spec-generator.js
@@ -46,6 +46,7 @@ module.exports = function createSwaggerObject(loopbackApplication, opts) {
   var swaggerObject = generateSwaggerObjectBase(opts);
 
   var typeRegistry = new TypeRegistry();
+  var operationIdRegistry = Object.create(null);
   var loopbackRegistry = loopbackApplication.registry ||
                          loopbackApplication.loopback.registry ||
                          loopbackApplication.loopback;
@@ -83,7 +84,8 @@ module.exports = function createSwaggerObject(loopbackApplication, opts) {
       return;
     }
 
-    routeHelper.addRouteToSwaggerPaths(route, classDef, typeRegistry,
+    routeHelper.addRouteToSwaggerPaths(route, classDef,
+                                       typeRegistry, operationIdRegistry,
                                        swaggerObject.paths);
   });
 

--- a/test/specgen/route-helper.test.js
+++ b/test/specgen/route-helper.test.js
@@ -109,7 +109,7 @@ describe('route-helper', function() {
         verb: 'get',
         path: 'path',
         description: ['1', '2', '3']
-      });
+      }, null, new TypeRegistry(), Object.create(null));
       expect(result.operation.summary).to.eql('1\n2\n3');
     });
 
@@ -119,7 +119,7 @@ describe('route-helper', function() {
         verb: 'get',
         path: 'path',
         notes: ['1', '2', '3']
-      });
+      }, null, new TypeRegistry(), Object.create(null));
       expect(result.operation.description).to.eql("1\n2\n3");
     });
   });
@@ -271,7 +271,7 @@ function createAPIDoc(def, classDef) {
     path: '/test',
     verb: 'GET',
     method: 'test.get'
-  }), classDef, new TypeRegistry());
+  }), classDef, new TypeRegistry(), Object.create(null));
 }
 
 function getResponseMessage(operationDoc) {


### PR DESCRIPTION
At the moment, the operation id is constructed as a remote method name.
However, it is posible to map a single method to multiple HTTP
endpoints (swagger paths)

For example, `PersistedModel.exists` is mapped to both

    HEAD /mymodels/{id}
    GET /mymodels/{id}/exists

As a result, the generated swagger operation ids are not unique.

This patch fixes the problem by detecting multi-endpoint methods
and appending HTTP verb and path to the name-based operation id.

Using the example above, the following operation ids are generated:

    Product.exists__head_Products_{id}
    Product.exists__get_Products_{id}_exists

Fix strongloop/loopback-component-explorer#132

/to @raymondfeng please review
/cc @ritch @sclaussen