### PR TITLE
Fix unused models + GeoPoint definition

### DIFF
--- a/lib/specgen/model-helper.js
+++ b/lib/specgen/model-helper.js
@@ -101,15 +101,9 @@ var modelHelper = module.exports = {
       var rel = modelCtor.relations[r];
       if (rel.modelTo) {
         modelHelper.registerModelDefinition(rel.modelTo, typeRegistry);
-        // TODO it shouldn't be necessary to reference the model here,
-        // let accepts/returns/property reference it instead
-        typeRegistry.reference(rel.modelTo.modelName);
       }
       if (rel.modelThrough) {
         modelHelper.registerModelDefinition(rel.modelThrough, typeRegistry);
-        // TODO it shouldn't be necessary to reference the model here,
-        // let accepts/returns/property reference it instead
-        typeRegistry.reference(rel.modelThrough.modelName);
       }
     }
   },

--- a/lib/specgen/type-registry.js
+++ b/lib/specgen/type-registry.js
@@ -10,7 +10,12 @@ function TypeRegistry() {
 
   this.register('x-any', { properties: {} });
   this.register('ObjectID', { type: 'string', pattern: '^[a-fA-F\\d]{24}$' });
-  this.register('GeoPoint', { properties: { lat: 'number', lng: 'number' } });
+  this.register('GeoPoint', {
+    properties: {
+      lat: { type: 'number' },
+      lng: { type: 'number' },
+    },
+  });
 }
 
 TypeRegistry.prototype.register = function(typeName, definition) {

--- a/test/specgen/swagger-spec-generator.test.js
+++ b/test/specgen/swagger-spec-generator.test.js
@@ -299,6 +299,30 @@ describe('swagger definition', function() {
       expect(Object.keys(swaggerResource.definitions))
         .to.include.members(['Address', 'Warehouse']);
     });
+
+    it('includes hidden models referenced by public models', function() {
+      var app = loopback({ localRegistry: true, loadBuiltinModels: true });
+      app.dataSource('db', { connector: 'memory' });
+      app.model(app.registry.AccessToken, { public: false, dataSource: 'db' });
+      app.model(app.registry.User, { public: true, dataSource: 'db' });
+
+      var swaggerResource = createSwaggerObject(app);
+
+      expect(Object.keys(swaggerResource.definitions))
+        .to.include.members(['AccessToken']);
+    });
+
+    it('excludes hidden models referenced by hidden models only', function() {
+      var app = loopback({ localRegistry: true, loadBuiltinModels: true });
+      app.dataSource('db', { connector: 'memory' });
+      app.model(app.registry.RoleMapping, { public: false, dataSource: 'db' });
+      app.model(app.registry.Role, { public: false, dataSource: 'db' });
+
+      var swaggerResource = createSwaggerObject(app);
+
+      expect(Object.keys(swaggerResource.definitions))
+        .to.not.include.members(['Role', 'RoleMapping']);
+    });
   });
 
   describe('paths node', function() {


### PR DESCRIPTION
**1. Fix hidden models referenced by hidden models**

By default, loopback apps come with two kinds of hidden models not
exposed via REST API:

 1) A private model than can be accessed via relation methods,
    for example AccessToken exposed via `/users/:id/accessTokens`

 2) A private model referenced by other private models only,
   for example Role and RoleModel.

The first kind should be included in swagger definitions, since it's
referenced in accepts/returns arguments of relation methods.

The second kind should be excluded, because it's not referenced at all.

This commit fixes the spec generator to exclude hidden models that are
refereced only by hidden models.

**2. Fix the definition of GeoPoint (introduced in #20) to be a valid Swagger definiton (JSON schema)**

/to @raymondfeng please review
/cc @0candy 

With these two changes in place, the swagger.json produced by loopback-example-app passes all validation in http://editor.swagger.io/