### PR TITLE
Treat property as type 'any' if not specified

### DIFF
--- a/lib/specgen/schema-builder.js
+++ b/lib/specgen/schema-builder.js
@@ -58,6 +58,10 @@ exports.buildFromLoopBackType = function(ldlDef, typeRegistry) {
   } else if (Array.isArray(ldlDef)) {
     ldlDef = { type: ldlDef };
   }
+  
+  if (!ldlDef.type) {
+    ldlDef = { type: 'any' };
+  }
 
   var schema = exports.buildMetadata(ldlDef);
   var ldlType = exports.getLdlTypeName(ldlDef.type);
@@ -149,7 +153,7 @@ exports.buildMetadata = function(ldlDef) {
     if (key in ldlDef) {
       // Skip null as swagger 2.x UI does not support it
       // https://github.com/swagger-api/swagger-spec/issues/229
-      if (ldlDef[key] != null) { 
+      if (ldlDef[key] != null) {
         result[KEY_TRANSLATIONS[key]] = ldlDef[key];
       }
     }

--- a/test/specgen/model-helper.test.js
+++ b/test/specgen/model-helper.test.js
@@ -123,6 +123,37 @@ describe('model-helper', function() {
     var def = getDefinitionsForModel(aClass.ctor).testModel;
     expect(def).to.not.have.property('required');
   });
+
+  describe('property converter', function() {
+    it('converts properties with no type to type "any"', function() {
+      var model = {};
+      model.definition = {
+        name: 'test',
+        properties: {
+          questionIndex: {
+            required: true
+          }
+        }
+      };
+      var defs = getDefinitionsForModel(model);
+      expect(defs.test.properties.questionIndex).to.have.property('$ref', '#/definitions/x-any');
+    });
+
+    it('converts array properties with no type to an array of type "any"', function() {
+      var model = {};
+      model.definition = {
+        name: 'test',
+        properties: {
+          questions: [{
+            required: true
+          }]
+        }
+      };
+      var defs = getDefinitionsForModel(model);
+      expect(defs.test.properties.questions).to.have.property('type', 'array');
+      expect(defs.test.properties.questions).to.have.property('items').eql({ '$ref': '#/definitions/x-any' });
+    });
+  });
 });
 
 // Simulates the format of a remoting class.


### PR DESCRIPTION
Connect to https://github.com/strongloop/loopback-swagger/issues/18

@bajtos Please review. Thanks!