### PR TITLE
Improve schema generation for return object

### DIFF
--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -96,19 +96,45 @@ var routeHelper = module.exports = {
     }
 
     if (routeReturns.length === 1 && routeReturns[0].root) {
-      if (routeReturns[0].model)
+      if (routeReturns[0].model) {
         return { $ref: typeRegistry.reference(routeReturns[0].model) };
+      }
       return schemaBuilder.buildFromLoopBackType(routeReturns[0], typeRegistry);
+    } else if (routeReturns.length === 1 && routeReturns[0].type === 'ReadableStream') {
+      return { type: 'file' };
     }
 
-    // Convert `returns` into a single object for later conversion into an
-    // operation object.
-    // TODO ad-hoc model definition in the case of multiple return values.
-    // It is enough to replace 'object' with an anonymous type definition
-    // based on all routeReturn items. The schema converter should take
-    // care of the remaning conversions.
-    var def = { type: 'object' };
-    return schemaBuilder.buildFromLoopBackType(def, typeRegistry);
+    // Construct scheme for the return object
+    var schema = { type: 'object' };
+    schema.required = [];
+    schema.properties = {};
+
+    routeReturns.forEach(function(ret) {
+      var propName = ret.name || ret.arg;
+      var idlType = schemaBuilder.getLdlTypeName(ret.type);
+      // Take care of array which can be nested.
+      // Note that we cannot simply use buildFromLoopBackType since it converts unknown type to
+      // '$ref': '#/definitions/UnknownType', whereas we decided to emit 'type: object' for such a case.
+      // See https://github.com/strongloop/loopback-swagger/pull/28#discussion_r54873911
+      // The following code is needed to take care of a nested array of an unknown type.
+      var itemIdlType = idlType;
+      var genericIdlType = { type: 'object' };
+      while (Array.isArray(itemIdlType)) {
+        itemIdlType = schemaBuilder.getLdlTypeName(itemIdlType[0]);
+        genericIdlType = { type: 'array', items: genericIdlType };
+      }
+      if (schemaBuilder.isPrimitiveType(itemIdlType)) {
+        schema.properties[propName] = schemaBuilder.buildFromLoopBackType(ret, typeRegistry);
+      } else {
+        console.warn('Swagger: temporarily using `object` instead of unknown type %j found in route %j', itemIdlType, route);
+        schema.properties[propName] = genericIdlType;
+      }
+      if (ret.required) {
+        schema.required.push(propName);
+      }
+    });
+
+    return schema;
   },
 
   /**

--- a/test/specgen/route-helper.test.js
+++ b/test/specgen/route-helper.test.js
@@ -4,19 +4,86 @@ var routeHelper = require('../../lib/specgen/route-helper');
 var TypeRegistry = require('../../lib/specgen/type-registry');
 var expect = require('chai').expect;
 var _defaults = require('lodash').defaults;
+var loopback = require('loopback');
 
 describe('route-helper', function() {
   it('returns "object" when a route has multiple return values', function() {
+    var TestModel = loopback.createModel('TestModel', {street: String});
     var entry = createAPIDoc({
       returns: [
         { arg: 'max', type: 'number' },
         { arg: 'min', type: 'number' },
-        { arg: 'avg', type: 'number' }
+        { name: 'avg', type: 'number' },
+        { name: 'str', type: String },
+        { name: 'strArray', type: [String] },
+        { name: 'testModel', type: TestModel },
+        { name: 'testModelStr', type: 'TestModel' },
+        { name: 'testModelArray', type: [TestModel] },
+        { name: 'testModelArrayArray', type: [[TestModel]] },
+        { name: 'unknownModel', type: 'UnknownModel' },
+        { name: 'requiredStr', type: String, required: true }
       ]
     });
-    // TODO use a custom (dynamicaly-created) model schema instead of "object"
-    expect(getResponseMessage(entry.operation))
-      .to.have.property('schema').eql({ type: 'object' });
+    var responseMessage = getResponseMessage(entry.operation);
+    (((responseMessage || {}).schema || {}).required || []).sort(); // sort the array for the comparison below
+    expect(responseMessage)
+      .to.have.property('schema').eql({
+        type: 'object',
+        properties: {
+          max: { type: 'number', format: 'double' },
+          min: { type: 'number', format: 'double' },
+          avg: { type: 'number', format: 'double' },                            
+          str: { type: 'string' },
+          strArray: {
+            items: {
+              type: 'string'
+            },
+            type: 'array'
+          },
+          testModel: {
+            type: 'object' // TODO - emit '$ref': '#/definitions/TestModel' after registering it
+          },
+          testModelArray: {
+            items: {
+              type: 'object' // TODO - emit '$ref': '#/definitions/TestModel' after registering it
+            },
+            type: 'array'
+          },
+          testModelArrayArray: {
+            items: {
+              items: {
+                type: 'object' // TODO - emit '$ref': '#/definitions/TestModel' after registering it
+              },
+              type: 'array'
+            },
+            type: 'array'
+          },
+          testModelStr: {
+            type: 'object' // TODO - emit '$ref': '#/definitions/TestModel' after registering it
+          },
+          unknownModel: {
+            type: 'object' // unknown model is converted to plain object
+          },
+          requiredStr: { type: 'string' }
+        },
+        required: [
+          'requiredStr'
+        ]
+      });
+  });
+
+  it('converts { type: ReadableStream\' } to { schema: { type: \'file\' } }', function() {
+    var TestModel = loopback.createModel('TestModel', {street: String});
+    var entry = createAPIDoc({
+      returns: [
+        { name: 'changes', type: 'ReadableStream' }
+      ]
+    });
+    var responseMessage = getResponseMessage(entry.operation);
+    expect(responseMessage)
+      .to.have.property('schema').eql({
+        type: 'file'
+      });
   });
 
   it('converts path params when they exist in the route name', function() {


### PR DESCRIPTION
Fix https://github.com/strongloop/loopback-swagger/issues/27

Updated loopback-swagger has been tested by generating Swagger Spec of [this test API server](https://docs.strongloop.com/display/public/LB/Create+a+simple+API), feeding it to [swagger-codegen](https://github.com/swagger-api/swagger-codegen) and writing a simple client in Swift using the swagger-codegen-generated SDK.  I tested invocation of `PersistedModel.count`, which demonstrated the issue, in the simple test client and made sure this fix works.

@bajtos would you please review the changes?