### PR TITLE
Handle {id} and . in operation id

### DIFF
--- a/lib/codegen/generator-v2.js
+++ b/lib/codegen/generator-v2.js
@@ -120,7 +120,9 @@ V2Generator.prototype.getOperations = function (spec) {
       }
 
       // Camelize the operation id
-      op.operationId = _s.camelize(op.operationId.split(/[\s\/-:\*]+/).join('_'));
+      op.operationId = op.operationId.replace(/{(([^{}])+)}/g, '_$1');
+      op.operationId = _s.camelize(
+        op.operationId.split(/[\.\s\/-:\*]+/).join('_'));
 
       var operation = new V2Operation(op);
       operation.getRemoting();

--- a/lib/codegen/model.ejs
+++ b/lib/codegen/model.ejs
@@ -12,9 +12,11 @@ function printParams() {
     return params.join('\n');
 }
 
+
 function printMethod() {
     var className = modelName || 'Model';
-    var method = className + '.' + op.operationId + ' = function(';
+    var method = className + '.' + op.operationId
+            + ' = function(';
     var params = op.accepts.map(function(a) {
         return a.arg;
     });

--- a/test/codegen/pet-expanded.json
+++ b/test/codegen/pet-expanded.json
@@ -30,7 +30,7 @@
     "/pets": {
       "get": {
         "description": "Returns all pets from the system that the user has access to",
-        "operationId": "findPets",
+        "operationId": "Pet.findPets",
         "produces": [
           "application/json",
           "application/xml",
@@ -112,7 +112,7 @@
     "/pets/{id}": {
       "get": {
         "description": "Returns a user based on a single ID, if the user does not have access to the pet",
-        "operationId": "findPetById",
+        "operationId": "findPetById{id}",
         "produces": [
           "application/json",
           "application/xml",

--- a/test/codegen/swagger-v2.test.js
+++ b/test/codegen/swagger-v2.test.js
@@ -2,6 +2,7 @@ var expect = require('chai').expect;
 var V2Generator = require('../../lib/codegen/generator-v2');
 
 var petStoreV2Spec = require('../../example/pet-store-2.0.json');
+var pet2 = require('./pet-expanded.json');
 var generator = new V2Generator();
 
 describe('Swagger spec v2 generator', function() {
@@ -10,6 +11,18 @@ describe('Swagger spec v2 generator', function() {
     var code = generator.generateRemoteMethods(petStoreV2Spec,
       {modelName: 'Store'});
     expect(code).to.be.string;
+  });
+
+  it('generates remote methods', function() {
+    var code = generator.generateRemoteMethods(pet2,
+      {modelName: 'Pet'});
+    expect(code).contain('Pet.PetFindPets = function(tags, limit, callback)');
+    expect(code).contain('Pet.remoteMethod(\'PetFindPets\'');
+    expect(code).contain('Pet.findPetByIdId = function(id, callback)');
+    expect(code).contain('Pet.remoteMethod(\'findPetByIdId\'');
+    expect(code).contain('Pet.deletePet = function(id, callback)');
+    expect(code).contain('Pet.remoteMethod(\'deletePet\'');
+
   });
 
   it('transform operations', function() {


### PR DESCRIPTION
The PR allows `{id}` and `.` in operationId.