### PR TITLE
expose object types as nested properties

### DIFF
--- a/lib/specgen/schema-builder.js
+++ b/lib/specgen/schema-builder.js
@@ -79,6 +79,16 @@ exports.buildFromLoopBackType = function(ldlDef, typeRegistry) {
     return schema;
   }
 
+  if (ldlType === 'object' && typeof ldlDef.type === 'object') {
+    var obj = {};
+    for (var prop in ldlDef.type) {
+      obj[prop] = exports.buildFromLoopBackType(ldlDef.type[prop], typeRegistry);
+    }
+    schema.type = 'object';
+    schema.properties = obj;
+    return schema;
+  }
+
   var ldlTypeLowerCase = ldlType.toLowerCase();
   switch (ldlTypeLowerCase) {
     case 'date':

--- a/test/specgen/schema-builder.test.js
+++ b/test/specgen/schema-builder.test.js
@@ -59,8 +59,38 @@ describe('schema-builder', function() {
     { in: { type: 'user' },
       out: { $ref: '#/definitions/user' }},
     // Anonymous type
-    { in: { type: { foo: 'string', bar: 'number' }},
-      out: { type: 'object' }},
+    { in: {
+      type: {
+        foo: 'string',
+        bar: 'number',
+        quux: {
+          type: {
+            quuux: 'date',
+          },
+        },
+      },
+    },
+    out: {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'string',
+        },
+        bar: {
+          type: 'number',
+          format: 'double',
+        },
+        quux: {
+          properties: {
+            quuux: {
+              format: 'date',
+              type: 'string',
+            },
+          },
+          type: 'object',
+        },
+      },
+    }},
   ]);
 
   describeTestCases('for extra metadata', [


### PR DESCRIPTION
For nested object types, we expose them under the "properties" property
recursively.