### PR TITLE
Do not generate required if no item is present

### DIFF
--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -105,7 +105,6 @@ var routeHelper = module.exports = {
 
     // Construct scheme for the return object
     var schema = { type: 'object' };
-    schema.required = [];
     schema.properties = {};
     routeReturns.forEach(function(ret) {
       var propName = ret.name || ret.arg;
@@ -130,6 +129,9 @@ var routeHelper = module.exports = {
         schema.properties[propName] = genericIdlType;
       }
       if (ret.required) {
+        if (schema.required == null) {
+          schema.required = [];
+        }
         schema.required.push(propName);
       }
     });

--- a/test/specgen/route-helper.test.js
+++ b/test/specgen/route-helper.test.js
@@ -72,6 +72,19 @@ describe('route-helper', function() {
       });
   });
 
+  it('does not produce required array if no required property is defined', function() {
+    var TestModel = loopback.createModel('TestModel', { street: String });
+    var entry = createAPIDoc({
+      returns: [
+        { arg: 'max', type: 'number' },
+        { arg: 'min', type: 'number' },
+      ],
+    });
+    var responseMessage = getResponseMessage(entry.operation);
+    expect(responseMessage.schema).to.not.have.property('required');
+  });
+
+
   it('converts { type: ReadableStream\' } to { schema: { type: \'file\' } }', function() {
     var TestModel = loopback.createModel('TestModel', { street: String });
     var entry = createAPIDoc({


### PR DESCRIPTION
The PR removes empty required for the response object. Otherwise, the generated swagger will fail the validation.