### PR TITLE
Remove requirement for responseModel property from remoteMethod errors array

### DIFF
--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -176,10 +176,14 @@ var routeHelper = module.exports = {
       // TODO define new LDL syntax that is status-code-indexed
       // and which allow users to specify headers & examples
       route.errors.forEach(function(msg) {
+        var schema = null;
+        if (msg.responseModel) {
+          schema = schemaBuilder.buildFromLoopBackType(msg.responseModel,
+                                                       typeRegistry);
+        }
         responseMessages[msg.code] = {
           description: msg.message,
-          schema: schemaBuilder.buildFromLoopBackType(msg.responseModel,
-                                                      typeRegistry),
+          schema: schema,
           // TODO - headers, examples
         };
       });

--- a/test/specgen/route-helper.test.js
+++ b/test/specgen/route-helper.test.js
@@ -316,6 +316,27 @@ describe('route-helper', function() {
     });
   });
 
+  it('allows setting NULL for `responseModel`', function() {
+    var doc = createAPIDoc({
+      errors: [{
+        code: 422,
+        message: 'Validation',
+        responseModel: null,
+      }],
+    });
+    expect(doc.schema).to.be.undefined;
+  });
+
+  it('allows setting omitting the `responseModel`', function() {
+    var doc = createAPIDoc({
+      errors: [{
+        code: 422,
+        message: 'Validation',
+      }],
+    });
+    expect(doc.schema).to.be.undefined;
+  });
+
   it('includes custom http status code and override default ' +
     'success code in `responseMessages`', function() {
     var doc = createAPIDoc({


### PR DESCRIPTION
At the moment when defining custom errors in a remote method, a `responseModel` property is required. Without one `loopback-swagger` will crash.

A workaround is to provide an empty object to `responseModel`, like this:
```
errors: [
  { code: 401, message: 'This is a test error', responseModel: {} }
]
```
However that results in an ugly looking swagger doc:
![screen shot 2016-06-10 at 10 00 24 am](https://cloud.githubusercontent.com/assets/301630/15950462/5bdb0f38-2ef2-11e6-81fa-47e637b268f7.png)

This commit allows the `responseModel` property to be omitted, resulting in a cleaner looking swagger doc:
![screen shot 2016-06-10 at 10 02 57 am](https://cloud.githubusercontent.com/assets/301630/15950476/88bd60a0-2ef2-11e6-8d86-ace6e845cbe1.png)