### PR TITLE
Allow object arguments to provide Model

### DIFF
--- a/lib/specgen/schema-builder.js
+++ b/lib/specgen/schema-builder.js
@@ -72,7 +72,12 @@ exports.buildFromLoopBackType = function(ldlDef, typeRegistry) {
   }
 
   var schema = exports.buildMetadata(ldlDef);
-  var ldlType = exports.getLdlTypeName(ldlDef.type);
+
+  var ldlType = ldlDef.type;
+  if (ldlType === 'object' && ldlDef.model) {
+    ldlType = ldlDef.model;
+  }
+  ldlType = exports.getLdlTypeName(ldlType);
 
   if (Array.isArray(ldlType)) {
     var itemLdl = ldlType[0] || 'any';

--- a/test/specgen/route-helper.test.js
+++ b/test/specgen/route-helper.test.js
@@ -374,6 +374,23 @@ describe('route-helper', function() {
       .to.have.property('schema')
       .eql({ $ref: '#/definitions/User' });
   });
+
+  it('supports `model` property', function() {
+    var doc = createAPIDoc(
+      {
+        accepts: [{
+          arg: 'result',
+          type: 'object',
+          model: 'User',
+          http: { source: 'body' },
+        }],
+      },
+      { name: 'User' });
+    var param = doc.operation.parameters[0];
+    expect(param)
+      .to.have.property('schema')
+      .eql({ $ref: '#/definitions/User' });
+  });
 });
 
 // Easy wrapper around createRoute


### PR DESCRIPTION
Add support for a new remoting metadata property "model". This new
property can be used for arguments of `type: 'object'` to instruct
the swagger-generator to use the provided model as a source of the
argument schema.

Connect to strongloop/loopback#1806

@gunjpan please review
cc @richardpringle