### PR TITLE
Remove juggler as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "eslint": "^2.7.0",
     "eslint-config-loopback": "^1.0.0",
     "loopback": "^3.0.0-alpha.5",
-    "loopback-datasource-juggler": "^3.0.0-alpha.8",
     "mocha": "^2.3.0"
   },
   "license": "MIT",


### PR DESCRIPTION
>IMPORTANT: In LoopBack v3.0, loopback-datasource-juggler is no longer a peer dependency that has to be explicitly listed in app/project package.json. Keep this in mind while creating `loopback-2.x` branches and updating `master` to use `loopback@3`.

* Remove juggler as a dependency

/to: @superkhau 
/cc: @bajtos