### PR TITLE
Fix date output format to "date-time"

### DIFF
--- a/lib/specgen/schema-builder.js
+++ b/lib/specgen/schema-builder.js
@@ -101,7 +101,7 @@ exports.buildFromLoopBackType = function(ldlDef, typeRegistry) {
   switch (ldlTypeLowerCase) {
     case 'date':
       schema.type = 'string';
-      schema.format = 'date';
+      schema.format = 'date-time';
       break;
     case 'buffer':
       schema.type = 'string';

--- a/test/specgen/schema-builder.test.js
+++ b/test/specgen/schema-builder.test.js
@@ -18,7 +18,7 @@ describe('schema-builder', function() {
   describeTestCases('for constructor types', [
     { in: String, out: { type: 'string' }},
     { in: Number, out: { type: 'number', format: 'double' }},
-    { in: Date, out: { type: 'string', format: 'date' }},
+    { in: Date, out: { type: 'string', format: 'date-time' }},
     { in: Boolean, out: { type: 'boolean' }},
     { in: Buffer, out: { type: 'string', format: 'byte' }},
   ]);
@@ -26,7 +26,7 @@ describe('schema-builder', function() {
   describeTestCases('for string types', [
     { in: 'string', out: { type: 'string' }},
     { in: 'number', out: { type: 'number', format: 'double' }},
-    { in: 'date', out: { type: 'string', format: 'date' }},
+    { in: 'date', out: { type: 'string', format: 'date-time' }},
     { in: 'boolean', out: { type: 'boolean' }},
     { in: 'buffer', out: { type: 'string', format: 'byte' }},
   ]);
@@ -39,7 +39,7 @@ describe('schema-builder', function() {
     { in: [{ type: 'string', maxLength: 64 }],
       out: { type: 'array', items: { type: 'string', maxLength: 64 }}},
     { in: [{ type: 'date' }],
-      out: { type: 'array', items: { type: 'string', format: 'date' }}},
+      out: { type: 'array', items: { type: 'string', format: 'date-time' }}},
     { in: [],
       out: { type: 'array', items: ANY_TYPE }},
     // This value is somehow provided by loopback-boot called from
@@ -83,7 +83,7 @@ describe('schema-builder', function() {
         quux: {
           properties: {
             quuux: {
-              format: 'date',
+              format: 'date-time',
               type: 'string',
             },
           },


### PR DESCRIPTION
Fix Swagger Spec generator to use "date-time" instead of "date" for JavaScript "Date" type.

See Swagger Spec 2.0
 - `date` - As defined by full-date - RFC3339
 - `date-time` - As defined by date-time - RFC3339

This patch supersedes #41
Fix #35

cc @B-Stefan