### PR TITLE
Coerce form to formData in accepts.http.source

### DIFF
--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -269,7 +269,9 @@ var routeHelper = module.exports = {
 
       // Check the http settings for the argument
       if (accepts.http && accepts.http.source) {
-        paramType = accepts.http.source;
+        paramType = accepts.http.source === 'form' ?
+          'formData' :
+          accepts.http.source;
       }
 
       // TODO: ensure that paramType has a valid value

--- a/test/specgen/route-helper.test.js
+++ b/test/specgen/route-helper.test.js
@@ -185,6 +185,15 @@ describe('route-helper', function() {
       var result = f({ description: ['1', '2', '3'] });
       expect(result.description).to.eql('1\n2\n3');
     });
+
+    it('coerces `form` to `formData` when checking http settings', function() {
+      var f = routeHelper.acceptToParameter(
+        { verb: 'put', path: 'path' },
+        A_CLASS_DEF,
+        new TypeRegistry());
+      var result = f({ http: { source: 'form' }});
+      expect(result.in).to.equal('formData');
+    });
   });
 
   describe('#routeToPathEntry', function() {


### PR DESCRIPTION
Swagger spec 2.0 supports "formData" instead of "form". This patch fixes
an API explorer bug for KeyValueModel PUT requests not honouring
`accepts.http.source: 'form'` as "formData".

Backport of #69 

cc @bajtos 