### PR TITLE
Omit null default values from schema

### DIFF
--- a/lib/specgen/schema-builder.js
+++ b/lib/specgen/schema-builder.js
@@ -189,6 +189,28 @@ exports.buildMetadata = function(ldlDef) {
     if (key in ldlDef)
       result[key] = ldlDef[key];
   }
+
+  if ('default' in result) {
+    // Skip null default values as the Swagger 2.x spec does not support null.
+    // This is applied to both top-level and nested property defaults.
+    // See: https://github.com/OAI/OpenAPI-Specification/issues/229
+    if (result.default === null) {
+      delete result.default;
+    } else if (typeof result.default === 'object') {
+      var deepNullFilter = function deepNullFilter(obj) {
+        Object.keys(obj).forEach(function(key) {
+          if (obj[key] === null) {
+            delete obj[key];
+          } else if (typeof obj[key] === 'object') {
+            deepNullFilter(obj[key]);
+          }
+        });
+      };
+
+      deepNullFilter(result.default);
+    }
+  }
+
   /* eslint-enable one-var */
   if (ldlDef.description) {
     result.description = typeConverter.convertText(ldlDef.description);

--- a/test/specgen/schema-builder.test.js
+++ b/test/specgen/schema-builder.test.js
@@ -108,6 +108,18 @@ describe('schema-builder', function() {
       out: { type: 'string', maxLength: 10 }},
     { in: { type: String, length: null },
       out: { type: 'string' }},
+    { in: { type: String, default: 'default-value' },
+      out: { type: 'string', default: 'default-value' }},
+    { in: { type: String, default: null },
+      out: { type: 'string' }},
+    { in: { type: String, default: { aaa: 'default-key-val' }},
+      out: { type: 'string', default: { aaa: 'default-key-val' }}},
+    { in: { type: String,
+            default: {
+              aaa: 'default-key-val',
+              bbb: null,
+              ccc: { ddd: 'val', eee: null }}},
+      out: { type: 'string', default: { aaa: 'default-key-val', ccc: { ddd: 'val' }}}},
   ]);
 
   describeTestCases('for built-in LoopBack types', [


### PR DESCRIPTION
### Description

This is due to the Swagger 2.x spec not supporting nulls.
Details: https://github.com/OAI/OpenAPI-Specification/issues/229

#### Related issues

strongloop/loopback-component-explorer#146

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
