### PR TITLE
Add support for file type #34

### DIFF
--- a/lib/codegen/spec-converter.js
+++ b/lib/codegen/spec-converter.js
@@ -16,7 +16,7 @@ function assign(target, targetProperty, source, sourceProperty, defaultValue) {
   }
 }
 
-var primitiveTypes = ['integer', 'number', 'string', 'boolean', 'File'];
+var primitiveTypes = ['integer', 'number', 'string', 'boolean', 'file'];
 
 module.exports.sourceVersion = 'Swagger 1.2';
 
@@ -140,11 +140,6 @@ function convertApi(v2, apiDeclaration, definitions) {
             target.items = props;
           } else {
             _.extend(target, props);
-          }
-          // Files hasn't made it over yet.
-          //
-          if (target.type === 'File') {
-            target.type = 'string';
           }
 
           assign(converted, 'x-typeArguments', parameter, 'typeArguments');

--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -298,6 +298,11 @@ var routeHelper = module.exports = {
         } else {
           paramObject.schema = schema;
         }
+      } else if (schema.type === 'file') {
+        paramObject.type = 'file';
+        paramObject.in = 'form';
+        paramObject.allowMultiple = false;
+        paramObject.description = 'File to upload';
       } else {
         var isComplexType = schema.type === 'object' ||
                             schema.type === 'array' ||

--- a/lib/specgen/schema-builder.js
+++ b/lib/specgen/schema-builder.js
@@ -19,6 +19,7 @@ var TYPES_PRIMITIVE = [
   'string',
   'object',
   'array',
+  'file',
 ];
 
 var KEY_TRANSLATIONS = {

--- a/lib/specgen/type-registry.js
+++ b/lib/specgen/type-registry.js
@@ -26,6 +26,7 @@ function TypeRegistry() {
     },
   });
   this.registerLoopbackType('DateString', {type: 'string', format: 'date-time'});
+  this.registerLoopbackType('file', {type: 'file'});
 }
 
 TypeRegistry.prototype.registerLoopbackType = function(typeName, definition) {

--- a/test/specgen/route-helper.test.js
+++ b/test/specgen/route-helper.test.js
@@ -103,6 +103,20 @@ describe('route-helper', function() {
       });
   });
 
+  it('converts { type: file\' } to { schema: { type: \'file\' } }', function() {
+    var TestModel = loopback.createModel('TestModel', {street: String});
+    var entry = createAPIDoc({
+      accepts: [
+        {name: 'changes', type: 'file'},
+      ],
+    });
+    var paramDoc = entry.operation.parameters[0];
+    expect(paramDoc).to.have.property('type', 'file');
+    expect(paramDoc).to.have.property('in', 'form');
+    expect(paramDoc).to.have.property('allowMultiple', false);
+    expect(paramDoc).to.have.property('description', 'File to upload');
+  });
+
   it('converts path params when they exist in the route name', function() {
     var entry = createAPIDoc({
       accepts: [


### PR DESCRIPTION
Also closes https://github.com/strongloop/loopback-component-explorer/issues/103

### Description

Allows `File` type to be turned into a file upload field.

#### Related issues

- #34
- https://github.com/strongloop/loopback-component-explorer/issues/103

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
