### PR TITLE
Support updateOnly feature

### DIFF
--- a/lib/specgen/model-helper.js
+++ b/lib/specgen/model-helper.js
@@ -39,8 +39,23 @@ var modelHelper = module.exports = {
     }
 
     typeRegistry.registerModel(name, function() {
-      return definitionFunction(modelCtor, typeRegistry);
+      return definitionFunction(modelCtor, typeRegistry, name);
     });
+
+    // check if ModelClass has getUpdateOnlyProperties() function defined to avoid version issues
+    if (lbdef.modelBuilder && lbdef.modelBuilder.defaultModelBaseClass &&
+        lbdef.modelBuilder.defaultModelBaseClass.getUpdateOnlyProperties) {
+      var updateOnlyProps =
+          lbdef.modelBuilder.defaultModelBaseClass.getUpdateOnlyProperties();
+      // if at least one updateOnly property is found, we need to create another model $new_xyz to be used only for
+      // create operation and this model will not have the updateOnly property included in the model. For e.g generated "id" field
+      if (updateOnlyProps && updateOnlyProps.length > 0) {
+        typeRegistry.registerModel('$new_' + name, function() {
+          return definitionFunction(modelCtor, typeRegistry,
+              '$new_' + name, updateOnlyProps);
+        });
+      }
+    }
   },
 
   isHiddenProperty: function(definition, propName) {
@@ -50,7 +65,7 @@ var modelHelper = module.exports = {
   },
 };
 
-var definitionFunction = function(modelCtor, typeRegistry) {
+var definitionFunction = function(modelCtor, typeRegistry, name, updateOnlyProps) {
   var lbdef = modelCtor.definition;
 
   var swaggerDef = {
@@ -85,8 +100,18 @@ var definitionFunction = function(modelCtor, typeRegistry) {
       swaggerDef.required.push(key);
     }
 
-    // Assign the schema to the properties object.
-    swaggerDef.properties[key] = schema;
+    // if model has updateOnly properties, check if current property we are trying to add is updateOnly.
+    // If yes, skip adding to the model since this model is used for create operation where generated/update
+    // only property should not exist
+    if (updateOnlyProps) {
+      if (!updateOnlyProps.includes(key)) {
+        // Assign the schema to the properties object.
+        swaggerDef.properties[key] = schema;
+      }
+    } else { // no updateOnlyProps. Add the property to the model
+      // Assign the schema to the properties object.
+      swaggerDef.properties[key] = schema;
+    }
   });
 
   if (lbdef.settings) {

--- a/lib/specgen/model-helper.js
+++ b/lib/specgen/model-helper.js
@@ -39,20 +39,23 @@ var modelHelper = module.exports = {
     }
 
     typeRegistry.registerModel(name, function() {
-      return definitionFunction(modelCtor, typeRegistry, name);
+      return definitionFunction(modelCtor, typeRegistry);
     });
 
-    // check if ModelClass has getUpdateOnlyProperties() function defined to avoid version issues
-    if (lbdef.modelBuilder && lbdef.modelBuilder.defaultModelBaseClass &&
-        lbdef.modelBuilder.defaultModelBaseClass.getUpdateOnlyProperties) {
-      var updateOnlyProps =
-          lbdef.modelBuilder.defaultModelBaseClass.getUpdateOnlyProperties();
-      // if at least one updateOnly property is found, we need to create another model $new_xyz to be used only for
-      // create operation and this model will not have the updateOnly property included in the model. For e.g generated "id" field
-      if (updateOnlyProps && updateOnlyProps.length > 0) {
-        typeRegistry.registerModel('$new_' + name, function() {
-          return definitionFunction(modelCtor, typeRegistry,
-              '$new_' + name, updateOnlyProps);
+    // check if ModelClass has defined getUpdateOnlyProperties() function to
+    // avoid version issues
+    if (modelCtor.getUpdateOnlyProperties) {
+      var excludeProps = modelCtor.getUpdateOnlyProperties();
+      // if at least one excludeProp is found, we need to create another model
+      // to be used only for create operation and this model will not have
+      // excludeProp included in the model. e.g generated "id" property
+      if (excludeProps && excludeProps.length > 0) {
+        const modelName = '$new_' + name;
+        typeRegistry.registerModel(modelName, function() {
+          var options = {
+            'excludeProps': excludeProps,
+          };
+          return definitionFunction(modelCtor, typeRegistry, options);
         });
       }
     }
@@ -65,7 +68,7 @@ var modelHelper = module.exports = {
   },
 };
 
-var definitionFunction = function(modelCtor, typeRegistry, name, updateOnlyProps) {
+var definitionFunction = function(modelCtor, typeRegistry, options) {
   var lbdef = modelCtor.definition;
 
   var swaggerDef = {
@@ -100,18 +103,13 @@ var definitionFunction = function(modelCtor, typeRegistry, name, updateOnlyProps
       swaggerDef.required.push(key);
     }
 
-    // if model has updateOnly properties, check if current property we are trying to add is updateOnly.
-    // If yes, skip adding to the model since this model is used for create operation where generated/update
-    // only property should not exist
-    if (updateOnlyProps) {
-      if (!updateOnlyProps.includes(key)) {
-        // Assign the schema to the properties object.
-        swaggerDef.properties[key] = schema;
-      }
-    } else { // no updateOnlyProps. Add the property to the model
-      // Assign the schema to the properties object.
-      swaggerDef.properties[key] = schema;
+    // if model has excludeProps properties, skip adding to the model since this
+    // model is used for create operation only where this property
+    // should not exist
+    if (options && options.excludeProps && options.excludeProps.includes(key)) {
+      return;
     }
+    swaggerDef.properties[key] = schema;
   });
 
   if (lbdef.settings) {

--- a/lib/specgen/model-helper.js
+++ b/lib/specgen/model-helper.js
@@ -45,17 +45,14 @@ var modelHelper = module.exports = {
     // check if ModelClass has defined getUpdateOnlyProperties() function to
     // avoid version issues
     if (modelCtor.getUpdateOnlyProperties) {
-      var excludeProps = modelCtor.getUpdateOnlyProperties();
+      const excludeProps = modelCtor.getUpdateOnlyProperties();
       // if at least one excludeProp is found, we need to create another model
       // to be used only for create operation and this model will not have
       // excludeProp included in the model. e.g generated "id" property
       if (excludeProps && excludeProps.length > 0) {
         const modelName = '$new_' + name;
         typeRegistry.registerModel(modelName, function() {
-          var options = {
-            'excludeProps': excludeProps,
-          };
-          return definitionFunction(modelCtor, typeRegistry, options);
+          return definitionFunction(modelCtor, typeRegistry, {excludeProps});
         });
       }
     }

--- a/lib/specgen/model-helper.js
+++ b/lib/specgen/model-helper.js
@@ -11,6 +11,7 @@
 var schemaBuilder = require('./schema-builder');
 var typeConverter = require('./type-converter');
 var TypeRegistry = require('./type-registry');
+var _ = require('lodash');
 
 /**
  * Export the modelHelper singleton.
@@ -103,7 +104,7 @@ var definitionFunction = function(modelCtor, typeRegistry, options) {
     // if model has excludeProps properties, skip adding to the model since this
     // model is used for create operation only where this property
     // should not exist
-    if (options && options.excludeProps && options.excludeProps.includes(key)) {
+    if (options && options.excludeProps && _.includes(options.excludeProps, key)) {
       return;
     }
     swaggerDef.properties[key] = schema;

--- a/lib/specgen/schema-builder.js
+++ b/lib/specgen/schema-builder.js
@@ -76,8 +76,9 @@ exports.buildFromLoopBackType = function(ldlDef, typeRegistry) {
 
   var ldlType = ldlDef.type;
   if (ldlType === 'object' && ldlDef.model) {
-    // if createOnlyInstance is set, use an instance which is specifically created for create operation.
-    // This instance will not contains updateOnly properties. For e.g generated "id" property.
+    // if createOnlyInstance is set, use an instance which is specifically
+    // created for create operation. This instance will not contains excludeOnly
+    // properties. For e.g generated "id" property.
     if (ldlDef.createOnlyInstance) {
       ldlType = '$new_' + ldlDef.model;
     } else {

--- a/lib/specgen/schema-builder.js
+++ b/lib/specgen/schema-builder.js
@@ -76,7 +76,13 @@ exports.buildFromLoopBackType = function(ldlDef, typeRegistry) {
 
   var ldlType = ldlDef.type;
   if (ldlType === 'object' && ldlDef.model) {
-    ldlType = ldlDef.model;
+    // if createOnlyInstance is set, use an instance which is specifically created for create operation.
+    // This instance will not contains updateOnly properties. For e.g generated "id" property.
+    if (ldlDef.createOnlyInstance) {
+      ldlType = '$new_' + ldlDef.model;
+    } else {
+      ldlType = ldlDef.model;
+    }
   }
   ldlType = exports.getLdlTypeName(ldlType);
 

--- a/test/specgen/swagger-spec-generator.test.js
+++ b/test/specgen/swagger-spec-generator.test.js
@@ -447,7 +447,8 @@ describe('swagger definition', function() {
           .to.include.members(['Product']);
     });
 
-    it('should use $new_Product definition for post/create operation', function() {
+    it('should use $new_Product definition for post/create operation when ' +
+        'forceId is in effect', function() {
       var app = createLoopbackAppWithModel();
       var swaggerResource = createSwaggerObject(app);
       // Post(create) operation should reference $new_Product
@@ -458,7 +459,8 @@ describe('swagger definition', function() {
           .to.equal('#/definitions/Product');
     });
 
-    it('should use Product swagger definition for all operations', function() {
+    it('should use Product swagger definition for all operations when ' +
+        'forceId is false', function() {
       const options = {
         forceId: false,
       };
@@ -477,11 +479,9 @@ describe('swagger definition', function() {
 
     app.dataSource('db', {connector: 'memory'});
 
-    var modelSettings;
-    if (options === undefined || options.forceId === undefined) {
-      modelSettings = {description: ['a-description', 'line2']};
-    } else {
-      modelSettings = {description: ['a-description', 'line2'], forceId: options.forceId};
+    const modelSettings = {description: ['a-description', 'line2']};
+    if (options && options.forceId !== undefined) {
+      modelSettings.forceId = options.forceId;
     }
 
     var Product = loopback.createModel('Product', {


### PR DESCRIPTION
This is part of solution forhttps://github.com/strongloop/loopback/issues/2924

Other PRs involved in the solution of issue https://github.com/strongloop/loopback/issues/2924
 - https://github.com/strongloop/loopback-datasource-juggler/pull/1453
 - https://github.com/strongloop/loopback/pull/3548

@bajtos Work In Progress PR. Please take a initial look.

This PR changes include

- check for createOnlyInstance in schema-builder.js to use a new model for create only
- defining and setting separate model for create operation based on updateOnly props - changes in model-helper.js

TODO:

Add a test case