### PR TITLE
Allow custom model tags and externalDocs

### DIFF
--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -206,7 +206,12 @@ var routeHelper = module.exports = {
     var verb = routeHelper.convertVerb(route.verb);
 
     var tags = [];
-    if (classDef && classDef.name) {
+    var swaggerSettings = classDef && classDef.ctor && classDef.ctor.settings &&
+      classDef.ctor.settings.swagger || {};
+
+    if (swaggerSettings.tag && swaggerSettings.tag.name) {
+      tags.push(swaggerSettings.tag.name);
+    } else if (classDef && classDef.name) {
       tags.push(classDef.name);
     }
 

--- a/lib/specgen/tag-builder.js
+++ b/lib/specgen/tag-builder.js
@@ -8,16 +8,19 @@
 var typeConverter = require('./type-converter');
 
 exports.buildTagFromClass = function(sharedClass) {
-  var name = sharedClass.name;
   var modelSettings = sharedClass.ctor && sharedClass.ctor.settings;
   var sharedCtor = sharedClass.ctor && sharedClass.ctor.sharedCtor;
+  var swaggerSettings = modelSettings && modelSettings.swagger || {};
+  var name = swaggerSettings.tag && swaggerSettings.tag.name || sharedClass.name;
 
   var description = modelSettings && modelSettings.description ||
     sharedCtor && sharedCtor.description;
 
+  var externalDocs = swaggerSettings.tag && swaggerSettings.tag.externalDocs;
+
   return {
     name: name,
     description: typeConverter.convertText(description),
-    // TODO: externalDocs: { description, url }
+    externalDocs: externalDocs,
   };
 };

--- a/test/specgen/route-helper.test.js
+++ b/test/specgen/route-helper.test.js
@@ -434,6 +434,14 @@ describe('route-helper', function() {
       .to.have.property('schema')
       .eql({$ref: '#/definitions/User'});
   });
+
+  it('allows a custom `tag` name to be set', function() {
+    var doc = createAPIDoc(
+      {},
+      {name: 'User', ctor: {settings: {swagger: {tag: {name: 'Member'}}}}});
+    expect(doc.operation.tags[0])
+      .to.eql('Member');
+  });
 });
 
 // Easy wrapper around createRoute

--- a/test/specgen/swagger-spec-generator.test.js
+++ b/test/specgen/swagger-spec-generator.test.js
@@ -128,7 +128,7 @@ describe('swagger definition', function() {
       var app = createLoopbackAppWithModel();
       var swaggerResource = createSwaggerObject(app);
       expect(swaggerResource.tags).to.eql([
-        {name: 'Product', description: 'a-description\nline2'},
+        {name: 'Product', description: 'a-description\nline2', externalDocs: undefined},
       ]);
     });
   });

--- a/test/specgen/tag-builder.test.js
+++ b/test/specgen/tag-builder.test.js
@@ -25,4 +25,20 @@ describe('tag-builder', function() {
 
     expect(tag.description).to.eql('1\n2\n3');
   });
+
+  it('should use custom swagger name if provided', function() {
+    var tag = tagBuilder.buildTagFromClass({
+      ctor: {settings: {swagger: {tag: {name: 'Something Else'}}}},
+    });
+
+    expect(tag.name).to.eql('Something Else');
+  });
+
+  it('sets external spec properties from model options', function() {
+    var tag = tagBuilder.buildTagFromClass({
+      ctor: {settings: {swagger: {tag: {externalDocs: {url: 'http://google.com'}}}}},
+    });
+
+    expect(tag.externalDocs).to.eql({url: 'http://google.com'});
+  });
 });


### PR DESCRIPTION
### Description

PR adds two new features

1. Specify a custom tag to be used for a model in the API explorer via 'tags' array
2. Allow `externalDocs` properties to be set on models.

Rationale:
1. The model name used in the app might not be what you want exposed in the explorer or you may want to use some other heading for various reasons (e.g. give it a prefix)
2. `externalDocs` has been a `TODO` in the code base for a long time.

Current implementation is on the `<model>.json` in the options.swagger property:

MyModel.json:

```json
{
  "name": "SomeModel",
  "options": {
    "swagger": {
      "tag": {
        "name": "_Models",
        "externalDocs": {
          "url": "http://my-external-spec.example.com"
        }
      }
    }
  }
}
```

Am opening to changing/moving the properties used to define these settings.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
