### PR TITLE
Set required to be true for path parameters

### DIFF
--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -292,7 +292,8 @@ var routeHelper = module.exports = {
         name: name,
         in: paramType,
         description: typeConverter.convertText(accepts.description),
-        required: !!accepts.required,
+        // For path parameters, required must be true
+        required: paramType === 'path' ? true : !!accepts.required,
       };
 
       var schema = schemaBuilder.buildFromLoopBackType(accepts, typeRegistry);

--- a/test/specgen/route-helper.test.js
+++ b/test/specgen/route-helper.test.js
@@ -127,7 +127,20 @@ describe('route-helper', function() {
     var paramDoc = entry.operation.parameters[0];
     expect(paramDoc).to.have.property('in', 'path');
     expect(paramDoc).to.have.property('name', 'id');
-    expect(paramDoc).to.have.property('required', false);
+    expect(paramDoc).to.have.property('required', true);
+  });
+
+  it('sets required to be true for path params', function() {
+    var entry = createAPIDoc({
+      accepts: [
+        {arg: 'id', type: 'string', http: {source: 'path'}},
+      ],
+      path: '/test/:id',
+    });
+    var paramDoc = entry.operation.parameters[0];
+    expect(paramDoc).to.have.property('in', 'path');
+    expect(paramDoc).to.have.property('name', 'id');
+    expect(paramDoc).to.have.property('required', true);
   });
 
   // FIXME need regex in routeHelper.acceptToParameter


### PR DESCRIPTION
Per swagger spec, the `required` field for path parameters
must be true

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop-internal/scrum-apex/issues/305

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
