### PR TITLE
Enable 'updateOnly' feature based on generateOperationScopedModels

### DIFF
--- a/lib/specgen/model-helper.js
+++ b/lib/specgen/model-helper.js
@@ -24,7 +24,7 @@ var modelHelper = module.exports = {
    * @param {TypeRegistry} typeRegistry Registry of types and models.
    * @return {Object} Associated model definition.
    */
-  registerModelDefinition: function(modelCtor, typeRegistry) {
+  registerModelDefinition: function(modelCtor, typeRegistry, opts) {
     var lbdef = modelCtor.definition;
 
     if (!lbdef) {
@@ -45,7 +45,7 @@ var modelHelper = module.exports = {
 
     // check if ModelClass has defined getUpdateOnlyProperties() function to
     // avoid version issues
-    if (modelCtor.getUpdateOnlyProperties) {
+    if (opts && opts.generateOperationScopedModels && modelCtor.getUpdateOnlyProperties) {
       const excludeProps = modelCtor.getUpdateOnlyProperties();
       // if at least one excludeProp is found, we need to create another model
       // to be used only for create operation and this model will not have

--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -41,10 +41,10 @@ var routeHelper = module.exports = {
    *   see https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#pathsObject
    */
   addRouteToSwaggerPaths: function(route, classDef, typeRegistry,
-                                   operationIdRegistry, paths) {
+                                   operationIdRegistry, paths, opts) {
     var entryToAdd = routeHelper.routeToPathEntry(route, classDef,
                                                   typeRegistry,
-                                                  operationIdRegistry);
+                                                  operationIdRegistry, opts);
     if (!(entryToAdd.path in paths)) {
       paths[entryToAdd.path] = {};
     }
@@ -58,7 +58,7 @@ var routeHelper = module.exports = {
    * @param  {TypeRegistry} typeRegistry Registry of types and models.
    * @return {Array}           Array of param docs.
    */
-  convertAcceptsToSwagger: function(route, classDef, typeRegistry) {
+  convertAcceptsToSwagger: function(route, classDef, typeRegistry, opts) {
     var accepts = route.accepts || [];
     var split = route.method.split('.');
     if (classDef && classDef.sharedCtor &&
@@ -85,7 +85,7 @@ var routeHelper = module.exports = {
 
     // Turn accept definitions in to parameter docs.
     accepts = accepts.map(
-      routeHelper.acceptToParameter(route, classDef, typeRegistry));
+      routeHelper.acceptToParameter(route, classDef, typeRegistry, opts));
 
     return accepts;
   },
@@ -154,11 +154,11 @@ var routeHelper = module.exports = {
    * See swagger-spec/2.0.md#pathItemObject
    */
   routeToPathEntry: function(route, classDef,
-                             typeRegistry, operationIdRegistry) {
+                             typeRegistry, operationIdRegistry, opts) {
     // Some parameters need to be altered; eventually most of this should
     // be removed.
     var accepts = routeHelper.convertAcceptsToSwagger(route, classDef,
-                                                      typeRegistry);
+                                                      typeRegistry, opts);
     var returns = routeHelper.convertReturnsToSwagger(route, typeRegistry);
     var statusCode = route.returns && route.returns.length ? 200 : 204;
 
@@ -264,7 +264,7 @@ var routeHelper = module.exports = {
    * A generator to convert from an sl-remoting-formatted "Accepts" description
    * to a Swagger-formatted "Parameter" description.
    */
-  acceptToParameter: function acceptToParameter(route, classDef, typeRegistry) {
+  acceptToParameter: function acceptToParameter(route, classDef, typeRegistry, opts) {
     var DEFAULT_TYPE =
       route.verb.toLowerCase() === 'get' ?  'query' : 'formData';
 
@@ -296,7 +296,7 @@ var routeHelper = module.exports = {
         required: paramType === 'path' ? true : !!accepts.required,
       };
 
-      var schema = schemaBuilder.buildFromLoopBackType(accepts, typeRegistry);
+      var schema = schemaBuilder.buildFromLoopBackType(accepts, typeRegistry, opts);
       if (paramType === 'body') {
         // HACK: Derive the type from model
         if (paramObject.name === 'data' && schema.type === 'object') {

--- a/lib/specgen/schema-builder.js
+++ b/lib/specgen/schema-builder.js
@@ -58,7 +58,7 @@ var SWAGGER_DATA_TYPE_FIELDS = [
  * @returns {Object} Swagger Schema Object that can be used as `schema` field
  *   or as a base for Parameter Object.
  */
-exports.buildFromLoopBackType = function(ldlDef, typeRegistry) {
+exports.buildFromLoopBackType = function(ldlDef, typeRegistry, opts) {
   assert(!!typeRegistry, 'typeRegistry is a required parameter');
 
   // Normalize non-object values to object format `{ type: XYZ }`
@@ -79,7 +79,7 @@ exports.buildFromLoopBackType = function(ldlDef, typeRegistry) {
     // if createOnlyInstance is set, use an instance which is specifically
     // created for create operation. This instance will not contains excludeOnly
     // properties. For e.g generated "id" property.
-    if (ldlDef.createOnlyInstance) {
+    if (opts && opts.generateOperationScopedModels && ldlDef.createOnlyInstance) {
       ldlType = '$new_' + ldlDef.model;
     } else {
       ldlType = ldlDef.model;

--- a/lib/specgen/swagger-spec-generator.js
+++ b/lib/specgen/swagger-spec-generator.js
@@ -60,7 +60,7 @@ module.exports = function createSwaggerObject(loopbackApplication, opts) {
                          loopbackApplication.loopback;
   var models = loopbackRegistry.modelBuilder.models;
   for (var modelName in models) {
-    modelHelper.registerModelDefinition(models[modelName], typeRegistry);
+    modelHelper.registerModelDefinition(models[modelName], typeRegistry, opts);
   }
 
   // A class is an endpoint root; e.g. /users, /products, and so on.
@@ -94,7 +94,7 @@ module.exports = function createSwaggerObject(loopbackApplication, opts) {
 
     routeHelper.addRouteToSwaggerPaths(route, classDef,
                                        typeRegistry, operationIdRegistry,
-                                       swaggerObject.paths);
+                                       swaggerObject.paths, opts);
   });
 
   _.assign(swaggerObject.definitions, typeRegistry.getDefinitions());

--- a/test/specgen/swagger-spec-generator.test.js
+++ b/test/specgen/swagger-spec-generator.test.js
@@ -414,7 +414,9 @@ describe('swagger definition', function() {
         function() {
           // forceId is undefined since forceId is not passed into the model
           var app = createLoopbackAppWithModel();
-          var swaggerResource = createSwaggerObject(app);
+          var swaggerResource = createSwaggerObject(app, {
+            generateOperationScopedModels: true,
+          });
           // Additional swagger object - $new_Product is generated since Product
           // model has generated ID and forceId is not set to false. This object
           // is used for create operation where it excludes 'id' property
@@ -427,7 +429,9 @@ describe('swagger definition', function() {
         forceId: true,
       };
       var app = createLoopbackAppWithModel(options);
-      var swaggerResource = createSwaggerObject(app);
+      var swaggerResource = createSwaggerObject(app, {
+        generateOperationScopedModels: true,
+      });
       // Additional swagger object - $new_Product is generated since Product
       // model has generated ID and forceId is not set to false. This object
       // is used for create operation where it excludes 'id' property
@@ -440,7 +444,9 @@ describe('swagger definition', function() {
         forceId: false,
       };
       var app = createLoopbackAppWithModel(options);
-      var swaggerResource = createSwaggerObject(app);
+      var swaggerResource = createSwaggerObject(app, {
+        generateOperationScopedModels: true,
+      });
       expect(Object.keys(swaggerResource.definitions))
           .to.not.include(['$new_Product']);
       expect(Object.keys(swaggerResource.definitions))
@@ -450,7 +456,9 @@ describe('swagger definition', function() {
     it('should use $new_Product definition for post/create operation when ' +
         'forceId is in effect', function() {
       var app = createLoopbackAppWithModel();
-      var swaggerResource = createSwaggerObject(app);
+      var swaggerResource = createSwaggerObject(app, {
+        generateOperationScopedModels: true,
+      });
       // Post(create) operation should reference $new_Product
       expect(swaggerResource.paths['/Products'].post.parameters[0].schema.$ref)
           .to.equal('#/definitions/$new_Product');
@@ -465,7 +473,9 @@ describe('swagger definition', function() {
         forceId: false,
       };
       var app = createLoopbackAppWithModel(options);
-      var swaggerResource = createSwaggerObject(app);
+      var swaggerResource = createSwaggerObject(app, {
+        generateOperationScopedModels: true,
+      });
       // post(create), patch or any other operation should reference Product
       expect(swaggerResource.paths['/Products'].post.parameters[0].schema.$ref)
           .to.equal('#/definitions/Product');

--- a/test/specgen/swagger-spec-generator.test.js
+++ b/test/specgen/swagger-spec-generator.test.js
@@ -482,6 +482,34 @@ describe('swagger definition', function() {
       expect(swaggerResource.paths['/Products'].patch.parameters[0].schema.$ref)
           .to.equal('#/definitions/Product');
     });
+
+    it('should generate one swagger model definitions when ' +
+        'generateOperationScopedModels is false',
+        function() {
+          var app = createLoopbackAppWithModel();
+          var swaggerResource = createSwaggerObject(app, {
+            generateOperationScopedModels: false,
+          });
+          // when generateOperationScopedModels is false, then even if forceId is true and
+          // generated id is true there will be only one model (Product) generated.
+          expect(Object.keys(swaggerResource.definitions))
+              .to.not.include(['$new_Product']);
+          expect(Object.keys(swaggerResource.definitions))
+              .to.include.members(['Product']);
+        });
+
+    it('should generate one swagger model definitions when ' +
+        'generateOperationScopedModels is undefined(false)',
+        function() {
+          var app = createLoopbackAppWithModel();
+          var swaggerResource = createSwaggerObject(app);
+          // when generateOperationScopedModels is undefined the value defaults to false. Then even if
+          // forceId is true and generated id is true there will be only one model (Product) generated.
+          expect(Object.keys(swaggerResource.definitions))
+              .to.not.include(['$new_Product']);
+          expect(Object.keys(swaggerResource.definitions))
+              .to.include.members(['Product']);
+        });
   });
 
   function createLoopbackAppWithModel(options) {


### PR DESCRIPTION
Enable 'updateOnly' feature based on generateOperationScopedModels flag. generateOperationScopedModels is a generated flag in component-config.json which get passed in through options[].