### PR TITLE
Fix file upload attachments

### DIFF
--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -305,7 +305,7 @@ var routeHelper = module.exports = {
         }
       } else if (schema.type === 'file') {
         paramObject.type = 'file';
-        paramObject.in = 'form';
+        paramObject.in = 'formData';
         paramObject.allowMultiple = false;
         paramObject.description = 'File to upload';
       } else {

--- a/test/specgen/route-helper.test.js
+++ b/test/specgen/route-helper.test.js
@@ -112,7 +112,7 @@ describe('route-helper', function() {
     });
     var paramDoc = entry.operation.parameters[0];
     expect(paramDoc).to.have.property('type', 'file');
-    expect(paramDoc).to.have.property('in', 'form');
+    expect(paramDoc).to.have.property('in', 'formData');
     expect(paramDoc).to.have.property('allowMultiple', false);
     expect(paramDoc).to.have.property('description', 'File to upload');
   });


### PR DESCRIPTION
### Description

`in: 'form'` was giving the correct input type but wasn't actually sending the file payload to the server. 'formData' fixes this.

#### Related issues

- closes #94

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
