### PR TITLE
Add support for examples in models and responses

### DIFF
--- a/lib/specgen/model-helper.js
+++ b/lib/specgen/model-helper.js
@@ -75,6 +75,11 @@ var definitionFunction = function(modelCtor, typeRegistry, options) {
     properties: {},
     required: [],
   };
+
+  if (lbdef.settings && lbdef.settings.swagger && lbdef.settings.swagger.example) {
+    swaggerDef.example = lbdef.settings.swagger.example;
+  }
+
   addSwaggerExtensions(lbdef.settings);
 
   var properties = lbdef.rawProperties || lbdef.properties;

--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -176,6 +176,11 @@ var routeHelper = module.exports = {
       // TODO - headers, examples
     };
 
+    if (route.returns && route.returns[0] && route.returns[0].example) {
+      responseMessages[statusCode].examples = responseMessages[statusCode].examples || {};
+      responseMessages[statusCode].examples['application/json'] = route.returns[0].example;
+    }
+
     if (route.errors) {
       // TODO define new LDL syntax that is status-code-indexed
       // and which allow users to specify headers & examples

--- a/lib/specgen/schema-builder.js
+++ b/lib/specgen/schema-builder.js
@@ -225,6 +225,9 @@ exports.buildMetadata = function(ldlDef) {
   } else if (ldlDef.doc) {
     result.description = typeConverter.convertText(ldlDef.doc);
   }
+  if (ldlDef.example) {
+    result.example = ldlDef.example;
+  }
 
   return result;
 };

--- a/test/specgen/model-helper.test.js
+++ b/test/specgen/model-helper.test.js
@@ -82,6 +82,23 @@ describe('model-helper', function() {
     });
   });
 
+  describe('examples', function() {
+    it('supports setting an example model', function() {
+      var aClass = createModelCtor({
+        content: 'string',
+      });
+      aClass.ctor.definition.settings = {
+        swagger: {
+          example: {content: 'Hello world!'},
+        },
+      };
+      var def = getDefinitionsForModel(aClass.ctor).testModel;
+      expect(def).to.have.property('example').and.to.eql(
+        {content: 'Hello world!'}
+      );
+    });
+  });
+
   describe('hidden properties', function() {
     it('should hide properties marked as "hidden"', function() {
       var aClass = createModelCtor({

--- a/test/specgen/route-helper.test.js
+++ b/test/specgen/route-helper.test.js
@@ -401,6 +401,18 @@ describe('route-helper', function() {
     expect(doc.operation.responses).to.not.have.property(204);
   });
 
+  it('supports example responses', function() {
+    var doc = createAPIDoc({
+      returns: [
+        {arg: 'something', http: {source: 'body'}, example: {foo: 'bar'}},
+      ],
+      path: '/test',
+    });
+    expect(doc.operation.responses['200']).to.property('examples');
+    expect(doc.operation.responses['200'].examples).to.have.property('application/json');
+    expect(doc.operation.responses['200'].examples['application/json']).to.eql({foo: 'bar'});
+  });
+
   it('includes custom http error status code in `responseMessages`', function() {
     var doc = createAPIDoc({
       http: {

--- a/test/specgen/schema-builder.test.js
+++ b/test/specgen/schema-builder.test.js
@@ -91,6 +91,49 @@ describe('schema-builder', function() {
           },
         },
       }},
+    {in: {
+      type: {
+        foo: 'string',
+        bar: 'number',
+      },
+      example: {
+        foo: 'something',
+        bar: 'something else',
+      },
+    },
+      out: {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string',
+          },
+          bar: {
+            type: 'number',
+            format: 'double',
+          },
+        },
+        example: {
+          foo: 'something',
+          bar: 'something else',
+        },
+      }},
+    {in: {
+      type: {
+        foo: {
+          type: 'string',
+          example: 'hello world',
+        },
+      },
+    },
+      out: {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string',
+            example: 'hello world',
+          },
+        },
+      }},
   ]);
 
   describeTestCases('for extra metadata', [


### PR DESCRIPTION
### Description

Add basic support for examples at the property, model and endpoint level for more rich documentation.

Property:

```json
"properties": {
  "name": {
    "type": "string",
     "example": "Marty McFly"
  }
}
```

Model:

```json
"options": {
   "swagger": {
      "example" : {
        "name": "Marty McFly",
        "occupation": "Time Traveller"
      }
   }
}
"properties": {
  "...": "..."
}
```

Endpoint:

```javascript
User.remoteMethod('register', {
  accepts: {
    arg: 'user',
    type: 'User',
    example: {
      name: 'Emmett Brown',
      occupation: 'Scientist'
    }
  }
// ...
})
```


- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
