### PR TITLE
Improve support for $ref

### DIFF
--- a/lib/codegen/generator-v2.js
+++ b/lib/codegen/generator-v2.js
@@ -43,10 +43,10 @@ V2Operation.prototype.parameter = function(p) {
     type = 'number';
   }
   if (p.type === 'array' && p.items) {
-    type = [p.items.type || this.resolveTypeRef(p.items.$ref)];
+    type = [p.items.type || this.resolveTypeRef(getRef(p.items))];
   }
-  if (p.schema && p.schema.$ref) {
-    type = this.resolveTypeRef(p.schema.$ref);
+  if (p.schema && getRef(p.schema)) {
+    type = this.resolveTypeRef(getRef(p.schema));
   } else if (p.schema && p.schema.type === 'object') {
     type = (this.name + '_' + p.name).replace(/\./g, '_');
     var schema = {};
@@ -86,8 +86,8 @@ V2Operation.prototype.getReturns = function() {
   for (code in this.responses) {
     var res = this.responses[code];
     if (code.match(/^2\d\d$/)) {
-      if (res.schema && res.schema.$ref) {
-        modelName = this.resolveTypeRef(res.schema.$ref);
+      if (res.schema && getRef(res.schema)) {
+        modelName = this.resolveTypeRef(getRef(res.schema));
         model = this.models[modelName];
         type = model ? modelName : 'Object';
         this.returnType = type || 'any';
@@ -99,14 +99,14 @@ V2Operation.prototype.getReturns = function() {
         });
       } else if (res.schema && res.schema.type === 'array' &&
         res.schema.items &&
-        res.schema.items.$ref) {
+        getRef(res.schema.items)) {
         /**
          * schema:
          *   type: array
          *   items:
          *     $ref: '#/definitions/Organization'
          */
-        modelName = this.resolveTypeRef(res.schema.items.$ref);
+        modelName = this.resolveTypeRef(getRef(res.schema.items));
         model = this.models[modelName];
         type = model ? modelName : 'Object';
         this.returnType = [type];
@@ -255,11 +255,11 @@ V2Generator.prototype.getOperations = function(spec) {
 
       if (implTemplate) {
         var template = implTemplate.template;
-        if (template && template.$ref &&
-          template.$ref.indexOf('#/x-implementation-templates/') === 0) {
+        if (template && getRef(template) &&
+          getRef(template).indexOf('#/x-implementation-templates/') === 0) {
           // The template is a ref to the global templates
           var templateName =
-            template.$ref.substring('#/x-implementation-templates/'.length);
+            getRef(template).substring('#/x-implementation-templates/'.length);
           if (templates[templateName]) {
             var templateStr = templates[templateName];
             if (templateStr.loopback) {
@@ -303,6 +303,11 @@ V2Generator.prototype.getOperations = function(spec) {
   }
   return operations;
 };
+
+function getRef(obj) {
+  return (obj != null && typeof obj === 'object') &&
+    (obj.$ref || obj.$REF);
+}
 
 module.exports = V2Generator;
 

--- a/lib/codegen/json-schema.js
+++ b/lib/codegen/json-schema.js
@@ -5,10 +5,18 @@
 
 'use strict';
 
+function getRef(obj) {
+  return (obj != null && typeof obj === 'object') &&
+    (obj.$ref || obj.$REF);
+}
+
 function resolveTypeRef(schema, ref) {
   if (typeof ref === 'string') {
     if (ref.indexOf('#/definitions/') === 0) {
       ref = ref.substring('#/definitions/'.length);
+    }
+    if (ref.indexOf('#/models/') === 0) {
+      ref = ref.substring('#/models/'.length);
     }
     var model = schema[ref];
     if (model) {
@@ -17,8 +25,8 @@ function resolveTypeRef(schema, ref) {
       }
       if (model.type === 'array') {
         var itemType = model.items.type;
-        if (model.items.$ref) {
-          itemType = resolveTypeRef(schema, model.items.$ref);
+        if (getRef(model.items)) {
+          itemType = resolveTypeRef(schema, getRef(model.items));
         }
         return [itemType];
       } else {
@@ -41,14 +49,14 @@ function buildProperty(schema, jsonModel, propertyName) {
   var property = {};
 
   var type = jsonProperty.type;
-  if (jsonProperty.$ref) {
-    type = resolveTypeRef(schema, jsonProperty.$ref);
+  if (getRef(jsonProperty)) {
+    type = resolveTypeRef(schema, getRef(jsonProperty));
   }
 
   if (type === 'array' && jsonProperty.items) {
     var itemType = jsonProperty.items.type;
-    if (jsonProperty.items.$ref) {
-      itemType = resolveTypeRef(schema, jsonProperty.items.$ref);
+    if (getRef(jsonProperty.items)) {
+      itemType = resolveTypeRef(schema, getRef(jsonProperty.items));
     }
     type = [itemType];
   }
@@ -61,7 +69,7 @@ function buildProperty(schema, jsonModel, propertyName) {
     property.required = true;
   }
   for (var a in jsonProperty) {
-    if (a === '$ref' || a === 'items' || (a in property)) {
+    if (a === '$ref' || a === '$REF' || a === 'items' || (a in property)) {
       continue;
     }
     property[a] = jsonProperty[a];
@@ -91,9 +99,9 @@ function buildModel(models, schema, jsonModel, modelName, anonymous) {
         required = required.concat(item.required);
       }
       var itemModel;
-      if (item.$ref) {
+      if (getRef(item)) {
         // Extract model name from reference object
-        base = models[item.$ref.substring('#/definitions/'.length)] || base;
+        base = models[getRef(item).substring('#/definitions/'.length)] || base;
         refs.push(base);
       } else {
         // Build the embedded model
@@ -138,8 +146,8 @@ function buildModel(models, schema, jsonModel, modelName, anonymous) {
     model.relations = {};
     for (var r in jsonModel['x-relations']) {
       var rel = jsonModel['x-relations'][r];
-      if (rel.partner && rel.partner.$ref) {
-        rel.model = resolveTypeRef(schema, rel.partner.$ref);
+      if (rel.partner && getRef(rel.partner)) {
+        rel.model = resolveTypeRef(schema, getRef(rel.partner));
         delete rel.partner;
       }
       model.relations[r] = rel;

--- a/test/codegen/pet-with-refs.json
+++ b/test/codegen/pet-with-refs.json
@@ -1,0 +1,269 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://helloreverb.com/terms/",
+    "contact": {
+      "name": "Wordnik API Team",
+      "email": "foo@example.com",
+      "url": "http://madskristensen.net"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
+    }
+  },
+  "host": "petstore.swagger.wordnik.com",
+  "basePath": "/api/pet-app",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "x-implementation-templates": {
+    "find": "${model}.find({limit: limit, where: {inq: tags}}, callback);"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "tags": ["Pet"],
+        "x-implementation-template":{
+          "template":{
+            "$ref": "#/x-implementation-templates/find"
+          },
+          "parameters": {
+            "model": "Pet"
+          }
+        },
+        "description": "Returns all pets from the system that the user has access to",
+        "operationId": "Pet.findPets",
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$REF": "#/definitions/pet"
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store.  Duplicates are allowed",
+        "operationId": "addPet",
+        "x-operation-name": "createPet",
+        "x-implementation" : [
+          "Pet.create(pet, callback);"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "Pet to add to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/newPet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "findPetById{id}",
+        "x-implementation-template" : {
+          "loopback": "Pet.findById(id, callback);"
+        },
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "stringList": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "petGroup": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "x-relations": {
+        "pets": {
+          "partner": {
+            "$ref": "#/definitions/pet"
+          },
+          "type": "hasMany",
+          "foreignKey": "groupId"
+        }
+      }
+    },
+    "pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tags": {
+          "$ref": "#/definitions/stringList"
+        }
+      }
+    },
+    "newPet": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/pet"
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "kind": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "errorModel": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/test/codegen/swagger-v2.test.js
+++ b/test/codegen/swagger-v2.test.js
@@ -13,6 +13,7 @@ var pet2 = require('./pet-expanded.json');
 var pet3 = require('./pet-without-tags.json');
 var pet4 = require('./pet-with-embedded-schema.json');
 var note = require('./note.json');
+var pet5 = require('./pet-with-refs.json');
 var generator = new V2Generator();
 
 describe('Swagger spec v2 generator', function() {
@@ -33,6 +34,18 @@ describe('Swagger spec v2 generator', function() {
 
   it('parse operations', function() {
     var operations = generator.getOperations(pet2);
+    expect(operations['/pet-app/pets'].get.returns).to.eql(
+      [{
+        description: 'pet response',
+        type: ['pet'],
+        arg: 'data',
+        root: true,
+      }]
+    );
+  });
+
+  it('parse operations with $REF', function() {
+    var operations = generator.getOperations(pet5);
     expect(operations['/pet-app/pets'].get.returns).to.eql(
       [{
         description: 'pet response',


### PR DESCRIPTION
To use swagger-parser in generator-loopback to deference $ref for
objects, we need to preserve $ref to derive model names

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
