### PR TITLE
add hideModels option

### DIFF
--- a/lib/specgen/swagger-spec-generator.js
+++ b/lib/specgen/swagger-spec-generator.js
@@ -42,6 +42,7 @@ module.exports = function createSwaggerObject(loopbackApplication, opts) {
       'application/javascript', 'text/javascript',
     ],
     version: getPackagePropertyOrDefault('version', '1.0.0'),
+    hideModels: [],
   });
 
   // We need a temporary REST adapter to discover our available routes.
@@ -60,7 +61,9 @@ module.exports = function createSwaggerObject(loopbackApplication, opts) {
                          loopbackApplication.loopback;
   var models = loopbackRegistry.modelBuilder.models;
   for (var modelName in models) {
-    modelHelper.registerModelDefinition(models[modelName], typeRegistry, opts);
+    if (false === _.includes(opts.hideModels, modelName)) {
+      modelHelper.registerModelDefinition(models[modelName], typeRegistry, opts);
+    }
   }
 
   // A class is an endpoint root; e.g. /users, /products, and so on.
@@ -68,6 +71,10 @@ module.exports = function createSwaggerObject(loopbackApplication, opts) {
   // using tags.
   classes.forEach(function(aClass) {
     if (!aClass.name) return;
+
+    if (true === _.includes(opts.hideModels, aClass.name)) {
+      return;
+    }
 
     var hasDocumentedMethods = aClass.methods().some(function(m) {
       return m.documented;
@@ -83,6 +90,11 @@ module.exports = function createSwaggerObject(loopbackApplication, opts) {
 
     // Get the class definition matching this route.
     var className = route.method.split('.')[0];
+
+    if (true === _.includes(opts.hideModels, className)) {
+      return;
+    }
+
     var classDef = classes.filter(function(item) {
       return item.name === className;
     })[0];


### PR DESCRIPTION

### Description

add hideModels, an array of loopback models to be excluded from the Swagger UI.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
