### PR TITLE
Prevent number from being defaulted to double

### DIFF
--- a/lib/specgen/schema-builder.js
+++ b/lib/specgen/schema-builder.js
@@ -117,7 +117,7 @@ exports.buildFromLoopBackType = function(ldlDef, typeRegistry, opts) {
       break;
     case 'number':
       schema.type = 'number';
-      schema.format = schema.format || 'double'; // All JS numbers are doubles
+      schema.format = schema.format || '';
       break;
     case 'any':
       schema.$ref = typeRegistry.reference('x-any');


### PR DESCRIPTION
Upon using swagger-codegen with Dart all numbers are defined as double.
This raises problems as the data from the api is not returned as "Floating-point numbers with double precision" as per Swagger defintion

https://swagger.io/docs/specification/data-models/data-types/

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
