### PR TITLE
Fix lodash vulnerability: Prototype Pollution

### DIFF
--- a/lib/codegen/spec-converter.js
+++ b/lib/codegen/spec-converter.js
@@ -36,7 +36,7 @@ function convertApi(v2, apiDeclaration, definitions) {
 
     // This assumes that the the schemes in the apiDeclaration basePath are the only ones supported.
     //
-    if (!_.contains(v2.schemes, base.scheme)) {
+    if (!_.includes(v2.schemes, base.scheme)) {
       v2.schemes.push(base.protocol.replace(':', ''));
     }
   }
@@ -108,7 +108,7 @@ function convertApi(v2, apiDeclaration, definitions) {
             props.schema = {
               '$ref': '#/definitions/' + parameter.items['$ref'],
             };
-          } else if (_.contains(primitiveTypes, parameter.type)) {
+          } else if (_.includes(primitiveTypes, parameter.type)) {
             props.type = parameter.type;
 
             if (parameter.format) {
@@ -171,7 +171,7 @@ function convertApi(v2, apiDeclaration, definitions) {
           response.schema.items = {
             '$ref': '#/definitions/' + operation.items['$ref'],
           };
-        } else if (_.contains(primitiveTypes, operation.type)) {
+        } else if (_.includes(primitiveTypes, operation.type)) {
           response.schema.type = operation.type;
 
           if (operation.format) {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "async": "^1.4.2",
     "debug": "^2.2.0",
     "ejs": "^2.5.5",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.5",
     "strong-globalize": "^2.6.0",
     "underscore.string": "~2.3.3"
   }


### PR DESCRIPTION
Upgraded lodash from v3 to v4

### Description

There is an NSP vulnerability warning reported for using lodash below v4 (Ref: https://nodesecurity.io/advisories/577)

These are the compatibility-warnings for upgrading lodash from v3 to v4 (https://github.com/lodash/lodash/wiki/Changelog#compatibility-warnings)

I took a quick look at the lodash usage in loopback-swagger 3.x, and these are all the functions:
- _.camelCase
- _.template
- **_.contains** -> **_.includes**
- _.map
- **_.each**
- **_.extend**
- _.isEmpty
- _.clone
- _.includes
- _.defaults
- _.assign
- _.cloneDeep
- _.matchesProperty
- _.property
- _.values

The only changes need here is to replace _.contains with _.includes in `/lib/code-gen/spec-converter.js`

#### Related issues

- connect to <https://github.com/strongloop/loopback-swagger/issues/120>
