### PR TITLE
specgen: emit correct non-root return types

### DIFF
--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -136,9 +136,14 @@ var routeHelper = module.exports = {
         schema.properties[propName] =
           schemaBuilder.buildFromLoopBackType(ret, typeRegistry);
       } else {
-        debug('Swagger: temporarily using `object` instead of unknown ' +
+        if (typeRegistry.isDefined(itemIdlType)) {
+          schema.properties[propName] =
+            schemaBuilder.buildFromLoopBackType(ret, typeRegistry);
+        } else {
+          debug('Swagger: temporarily using `object` instead of unknown ' +
           'type %j found in route %j', itemIdlType, route);
-        schema.properties[propName] = genericIdlType;
+          schema.properties[propName] = genericIdlType;
+        }
       }
       if (ret.required) {
         if (schema.required == null) {


### PR DESCRIPTION
### Description
Fixed the issue where return types not set as a root property were not being set as loopback model references.

#### Related issues

- fix #126 
- fix strongloop/loopback#2447

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
