### PR TITLE
Upgrade eslint-config-loopback + fix formatting

### DIFF
--- a/lib/specgen/model-helper.js
+++ b/lib/specgen/model-helper.js
@@ -71,7 +71,8 @@ var definitionFunction = function(modelCtor, typeRegistry, options) {
 
   var swaggerDef = {
     description: typeConverter.convertText(
-      lbdef.description || (lbdef.settings && lbdef.settings.description)),
+      lbdef.description || (lbdef.settings && lbdef.settings.description)
+    ),
     properties: {},
     required: [],
   };

--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -88,7 +88,8 @@ var routeHelper = module.exports = {
 
     // Turn accept definitions in to parameter docs.
     accepts = accepts.map(
-      routeHelper.acceptToParameter(route, classDef, typeRegistry, opts));
+      routeHelper.acceptToParameter(route, classDef, typeRegistry, opts)
+    );
 
     return accepts;
   },

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "eslint": "^5.0.1",
-    "eslint-config-loopback": "^10.0.0",
+    "eslint": "^5.1.0",
+    "eslint-config-loopback": "^11.0.0",
     "loopback": "^3.0.0",
     "mocha": "^5.2.0"
   },

--- a/test/codegen/swagger-v2.test.js
+++ b/test/codegen/swagger-v2.test.js
@@ -69,7 +69,8 @@ describe('Swagger spec v2 generator', function() {
     expect(code).contain('Pet.remoteMethod(\'createPet\'');
     expect(code).contain('type: [ \'pet\' ],');
     expect(code).contain(
-      'Pet.find({limit: limit, where: {inq: tags}}, callback);');
+      'Pet.find({limit: limit, where: {inq: tags}}, callback);'
+    );
     expect(code).contain('Pet.create(pet, callback);');
     expect(code).contain('Pet.findById(id, callback);');
   });
@@ -91,7 +92,8 @@ describe('Swagger spec v2 generator', function() {
     var code = generator.generateRemoteMethods(pet4,
       {modelName: 'Pet'});
     expect(code.Pet).contain(
-      'Pet.findPets = function(x_tags, x_limit, callback)');
+      'Pet.findPets = function(x_tags, x_limit, callback)'
+    );
   });
 
   it('generates embedded models', function() {

--- a/test/specgen/route-helper.test.js
+++ b/test/specgen/route-helper.test.js
@@ -277,7 +277,8 @@ describe('route-helper', function() {
       var f = routeHelper.acceptToParameter(
         {verb: 'get', path: 'path'},
         A_CLASS_DEF,
-        new TypeRegistry());
+        new TypeRegistry()
+      );
       var result = f({description: ['1', '2', '3']});
       expect(result.description).to.eql('1\n2\n3');
     });
@@ -286,7 +287,8 @@ describe('route-helper', function() {
       var f = routeHelper.acceptToParameter(
         {verb: 'put', path: 'path'},
         A_CLASS_DEF,
-        new TypeRegistry());
+        new TypeRegistry()
+      );
       var result = f({http: {source: 'form'}});
       expect(result.in).to.equal('formData');
     });
@@ -488,7 +490,8 @@ describe('route-helper', function() {
   it('adds class name to `tags`', function() {
     var doc = createAPIDoc(
       {method: 'User.login'},
-      {name: 'User'});
+      {name: 'User'}
+    );
     expect(doc.operation.tags).to.contain('User');
   });
 
@@ -506,7 +509,8 @@ describe('route-helper', function() {
       {
         accepts: [{arg: 'data', type: 'object', http: {source: 'body'}}],
       },
-      {name: 'User'});
+      {name: 'User'}
+    );
     var param = doc.operation.parameters[0];
     expect(param)
       .to.have.property('schema')
@@ -523,7 +527,8 @@ describe('route-helper', function() {
           http: {source: 'body'},
         }],
       },
-      {name: 'User'});
+      {name: 'User'}
+    );
     var param = doc.operation.parameters[0];
     expect(param)
       .to.have.property('schema')
@@ -533,7 +538,8 @@ describe('route-helper', function() {
   it('allows a custom `tag` name to be set', function() {
     var doc = createAPIDoc(
       {},
-      {name: 'User', ctor: {settings: {swagger: {tag: {name: 'Member'}}}}});
+      {name: 'User', ctor: {settings: {swagger: {tag: {name: 'Member'}}}}}
+    );
     expect(doc.operation.tags[0])
       .to.eql('Member');
   });


### PR DESCRIPTION
The new version of our config enabled function-paren-newline rule, this commit fixes the codebase to use more consistent handling of newlines when calling functions.

See strongloop/eslint-config-loopback#29

/cc @Danwakeem
