### PR TITLE
Fix return arguments which htttp.target is status|header being added to swagger return body

### DIFF
--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -107,6 +107,12 @@ var routeHelper = module.exports = {
       return undefined;
     }
 
+    // Filter out arguments having http.target set to 'header' or 'status'
+    routeReturns = routeReturns.filter(function(arg) {
+      const target = arg.http && arg.http.target;
+      return target !== 'header' && target !== 'status';
+    });
+
     if (routeReturns.length === 1 && routeReturns[0].root) {
       if (routeReturns[0].model) {
         return {$ref: typeRegistry.reference(routeReturns[0].model)};

--- a/test/specgen/route-helper.test.js
+++ b/test/specgen/route-helper.test.js
@@ -80,6 +80,22 @@ describe('route-helper', function() {
       });
   });
 
+  it('does not include arguments having http.target set to header|status', function() {
+    var TestModel = loopback.createModel('TestModel', {street: String});
+    var entry = createAPIDoc({
+      returns: [
+        {name: 'changes', type: 'ReadableStream'},
+        {name: 'status', type: 'number', http: {target: 'status'}},
+        {name: 'header', type: 'string', http: {target: 'header'}},
+      ],
+    });
+    var responseMessage = getResponseMessage(entry.operation);
+    expect(responseMessage)
+      .to.have.property('schema').eql({
+        type: 'file',
+      });
+  });
+
   it('does not produce required array if no required property is defined', function() {
     var TestModel = loopback.createModel('TestModel', {street: String});
     var entry = createAPIDoc({


### PR DESCRIPTION
### Description
Fix #130 
Filter out the return arguments if the `http.target` is set to `status|header` when converting returns to swagger.

#### Related issues
- connect to #130 
<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
