### PR TITLE
specgen: Retrieve description from package.json

### DIFF
--- a/lib/specgen/swagger-spec-generator.js
+++ b/lib/specgen/swagger-spec-generator.js
@@ -121,6 +121,13 @@ function generateSwaggerObjectBase(opts, loopbackApplication) {
     apiInfo.title = getPackagePropertyOrDefault('name', 'LoopBack Application');
   }
 
+  if (!apiInfo.description) {
+    apiInfo.description = getPackagePropertyOrDefault(
+      'description',
+      'LoopBack Application'
+    );
+  }
+
   var basePath = opts.basePath;
   if (basePath && /\/$/.test(basePath))
     basePath = basePath.slice(0, -1);

--- a/test/specgen/swagger-spec-generator.test.js
+++ b/test/specgen/swagger-spec-generator.test.js
@@ -46,6 +46,13 @@ describe('swagger definition', function() {
       expect(swaggerResource.info)
         .to.have.property('title', 'loopback-swagger');
     });
+
+    it('provides info.description', function() {
+      expect(swaggerResource.info).to.have.property(
+        'description',
+        'Integration between LoopBack and Swagger API specs'
+      );
+    });
   });
 
   describe('basePath', function() {


### PR DESCRIPTION
### Description
This patch retrieves a project description from package.json

#### Related issues
-connect to #122 

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
