### PR TITLE
Allow tag or param names to contain '-' or spaces

### DIFF
--- a/lib/codegen/generator-base.js
+++ b/lib/codegen/generator-base.js
@@ -11,6 +11,10 @@ var _cloneDeep = require('lodash').cloneDeep;
 
 var template = require('./model-template');
 
+function normalizeName(name) {
+  return name.replace(/[\-\.\s]/g, '_');
+}
+
 function BaseGenerator(options) {
   this.options = options || {};
 }
@@ -89,12 +93,13 @@ BaseGenerator.prototype.mapTagsToModels = function(spec, options) {
   var definitions = spec.definitions || spec.models;
 
   function mapTag(tag) {
-    if (!definitions[tag]) {
+    var modelName = normalizeName(tag);
+    if (!definitions[modelName]) {
       // Add a controller to definitions so that it will be generated
       // as a model
-      definitions[tag] = {
+      definitions[modelName] = {
         type: 'object',
-        name: tag,
+        name: modelName,
         'x-base-type': 'Model',
         properties: {},
       };
@@ -143,9 +148,10 @@ BaseGenerator.prototype.generateRemoteMethods = function(spec, options) {
   var operationList = {};
 
   function mapTag(tag) {
-    var ops = operationList[tag];
+    var modelName = normalizeName(tag);
+    var ops = operationList[modelName];
     if (!ops) {
-      ops = operationList[tag] = [];
+      ops = operationList[modelName] = [];
     }
     var copy = _cloneDeep(op);
     copy.models = op.models; // Keep the same ref to models

--- a/test/codegen/pet-with-special-names.json
+++ b/test/codegen/pet-with-special-names.json
@@ -1,0 +1,269 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://helloreverb.com/terms/",
+    "contact": {
+      "name": "Wordnik API Team",
+      "email": "foo@example.com",
+      "url": "http://madskristensen.net"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
+    }
+  },
+  "host": "petstore.swagger.wordnik.com",
+  "basePath": "/api/pet-app",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "x-implementation-templates": {
+    "find": "${model}.find({limit: x_limit, where: {inq: tags}}, callback);"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "tags": ["Pet Controller"],
+        "x-implementation-template":{
+          "template":{
+            "$ref": "#/x-implementation-templates/find"
+          },
+          "parameters": {
+            "model": "Pet"
+          }
+        },
+        "description": "Returns all pets from the system that the user has access to",
+        "operationId": "Pet.findPets",
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "x-limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/pet"
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store.  Duplicates are allowed",
+        "operationId": "addPet",
+        "x-operation-name": "createPet",
+        "x-implementation" : [
+          "Pet.create(pet, callback);"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "Pet to add to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/newPet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "findPetById{id}",
+        "x-implementation-template" : {
+          "loopback": "Pet.findById(id, callback);"
+        },
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "stringList": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "petGroup": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "x-relations": {
+        "pets": {
+          "partner": {
+            "$ref": "#/definitions/pet"
+          },
+          "type": "hasMany",
+          "foreignKey": "groupId"
+        }
+      }
+    },
+    "pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tags": {
+          "$ref": "#/definitions/stringList"
+        }
+      }
+    },
+    "newPet": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/pet"
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "kind": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "errorModel": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/test/codegen/swagger-v2.test.js
+++ b/test/codegen/swagger-v2.test.js
@@ -7,6 +7,7 @@
 
 var expect = require('chai').expect;
 var V2Generator = require('../../lib/codegen/generator-v2');
+var generateModels = require('../../index').generateModels;
 
 var petStoreV2Spec = require('../../example/pet-store-2.0.json');
 var pet2 = require('./pet-expanded.json');
@@ -14,6 +15,7 @@ var pet3 = require('./pet-without-tags.json');
 var pet4 = require('./pet-with-embedded-schema.json');
 var note = require('./note.json');
 var pet5 = require('./pet-with-refs.json');
+var pet6 = require('./pet-with-special-names.json');
 var generator = new V2Generator();
 
 describe('Swagger spec v2 generator', function() {
@@ -25,11 +27,26 @@ describe('Swagger spec v2 generator', function() {
 
   it('generates remote methods without tags', function() {
     generator.mapTagsToModels(pet3);
-    var models = require('../../index').generateModels(pet3);
+    var models = generateModels(pet3);
     expect(models.SwaggerModel).to.be.a('object');
     var code = generator.generateRemoteMethods(pet3);
     expect(code.SwaggerModel).to.be.a('string');
     expect(Object.keys(code)).to.eql(['SwaggerModel']);
+  });
+
+  it('generates remote methods with special names', function() {
+    generator.mapTagsToModels(pet6);
+    var models = generateModels(pet6);
+    expect(models.Pet_Controller).to.be.a('object');
+    var code = generator.generateRemoteMethods(pet6);
+    expect(code.Pet_Controller).to.be.a('string');
+    var petController = code.Pet_Controller;
+    expect(petController).to.contain(
+      'Pet_Controller.petFindPets = function(tags, x_limit, callback) {'
+    );
+    expect(petController).to.contain(
+      'Pet.find({limit: x_limit, where: {inq: tags}}, callback);'
+    );
   });
 
   it('parse operations', function() {


### PR DESCRIPTION
### Description

reported by a customer.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
