### PR TITLE
Check for route.http.errorStatus before adding it to responseMessages

### DIFF
--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -210,7 +210,7 @@ var routeHelper = module.exports = {
       });
     }
 
-    if (route.http) {
+    if (route.http && route.http.errorStatus) {
       var errorStatus = route.http.errorStatus;
       if (!responseMessages[errorStatus]) {
         responseMessages[errorStatus] = {

--- a/test/specgen/route-helper.test.js
+++ b/test/specgen/route-helper.test.js
@@ -475,6 +475,32 @@ describe('route-helper', function() {
     expect(doc.operation.responses).to.not.have.property(204);
   });
 
+  it('includes custom http errorStatus', function() {
+    const doc = createAPIDoc({
+      http: {
+        status: 201,
+        errorStatus: 404,
+      },
+    });
+
+    const responses = doc.operation.responses;
+    expect(Object.keys(responses)).to.eql(['201', '404']);
+    expect(responses['404']).to.eql({
+      description: 'Unknown error',
+    });
+  });
+
+  it('does not include `undefined` error response in `responseMessages` when ' +
+    'http is set, but erorrStatus is not set', function() {
+    const doc = createAPIDoc({
+      http: {
+        status: 201,
+      },
+    });
+
+    expect(Object.keys(doc.operation.responses)).to.eql(['201']);
+  });
+
   it('supports example responses', function() {
     var doc = createAPIDoc({
       returns: [


### PR DESCRIPTION
### Description
Before the fix an undefined error message was added to responseMessages when `route.http` was set, but not `route.http.errorStatus`.

![grafik](https://user-images.githubusercontent.com/815915/66704995-c23d1f00-ed21-11e9-9de1-339669592625.png)


#### Related issues

- connect to strongloop/strong-remoting#475

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
