### PR TITLE
Include relation properties

### DIFF
--- a/lib/specgen/model-helper.js
+++ b/lib/specgen/model-helper.js
@@ -57,6 +57,13 @@ var modelHelper = module.exports = {
         });
       }
     }
+
+    if (opts && opts.generateRelationProperties) {
+      const modelNameWithRelations = name + 'WithRelations';
+      typeRegistry.registerModel(modelNameWithRelations, function() {
+        return definitionFunction(modelCtor, typeRegistry, {includeRelations: true});
+      });
+    }
   },
 
   isHiddenProperty: function(definition, propName) {
@@ -149,6 +156,41 @@ var definitionFunction = function(modelCtor, typeRegistry, options) {
     }
     if (rel.modelThrough) {
       modelHelper.registerModelDefinition(rel.modelThrough, typeRegistry);
+    }
+
+    var prop = null;
+    var relationOptions = rel.options || {};
+
+    if (options && !!options.includeRelations) {
+      if (!relationOptions.disableInclude) {
+        const modelNameWithRelations = rel.modelTo.modelName + 'WithRelations';
+        // now we make it look like a loopback property definition
+        switch (rel.type) {
+          case 'hasMany':
+          case 'hasManyThrough':
+          case 'hasAndBelongsToMany':
+          case 'embedsMany':
+          case 'referencesMany':
+            prop = [modelNameWithRelations];
+            break;
+          case 'hasOne':
+          case 'belongsTo':
+          case 'embedsOne':
+            prop = modelNameWithRelations;
+            break;
+          default:
+            // there above were all relation types covered in the docs
+            // so we shouldn't be here -- log some error?
+        }
+
+        if (prop) {
+          // Get a type out of the constructors we were passed.
+          var schema = schemaBuilder.buildFromLoopBackType(prop, typeRegistry, options);
+
+          // Assign the schema to the properties object.
+          swaggerDef.properties[r] = schema;
+        }
+      }
     }
   }
   /* eslint-enable one-var */

--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -99,7 +99,17 @@ var routeHelper = module.exports = {
    * @param  {Object} route    Strong Remoting Route object.
    * @return {Object}          A single returns param doc.
    */
-  convertReturnsToSwagger: function(route, typeRegistry) {
+  convertReturnsToSwagger: function(route, typeRegistry, opts) {
+    if (opts && opts.generateRelationProperties) {
+      if (route.method.match(/\.(find|findOne|findById|__(get|findById)__*)/)) {
+        var returns = route.returns;
+        var type = returns[0].type;
+        var newType = type + 'WithRelations';
+        returns[0].type = Array.isArray(type) ? [newType] : newType;
+        route.returns = returns;
+      }
+    }
+
     var routeReturns = route.returns;
     if (!routeReturns || !routeReturns.length) {
       // An operation that returns nothing will have
@@ -174,7 +184,7 @@ var routeHelper = module.exports = {
     // be removed.
     var accepts = routeHelper.convertAcceptsToSwagger(route, classDef,
       typeRegistry, opts);
-    var returns = routeHelper.convertReturnsToSwagger(route, typeRegistry);
+    var returns = routeHelper.convertReturnsToSwagger(route, typeRegistry, opts);
     var statusCode = route.returns && route.returns.length ? 200 : 204;
 
     if (route.http && route.http.status) {

--- a/lib/specgen/schema-builder.js
+++ b/lib/specgen/schema-builder.js
@@ -81,6 +81,8 @@ exports.buildFromLoopBackType = function(ldlDef, typeRegistry, opts) {
     // properties. For e.g generated "id" property.
     if (opts && opts.generateOperationScopedModels && ldlDef.createOnlyInstance) {
       ldlType = '$new_' + ldlDef.model;
+    } else if (opts && opts.generateRelationProperties) {
+      ldlType = ldlDef.model + 'WithRelations';
     } else {
       ldlType = ldlDef.model;
     }

--- a/lib/specgen/swagger-spec-generator.js
+++ b/lib/specgen/swagger-spec-generator.js
@@ -27,7 +27,27 @@ var TypeRegistry = require('./type-registry');
  * @returns {Object}
  */
 module.exports = function createSwaggerObject(loopbackApplication, opts) {
-  opts = _.defaults(opts || {}, {
+  // We need a temporary REST adapter to discover our available routes.
+  var remotes = loopbackApplication.remotes();
+  var adapter = remotes.handler('rest').adapter;
+  var routes = adapter.allRoutes();
+  var classes = remotes.classes();
+
+  opts = opts || {};
+  var swaggerSpecExtensions = Object.assign({}, loopbackApplication.get('swagger'));
+
+  var swaggerOptions = {
+    generateOperationScopedModels: swaggerSpecExtensions.generateOperationScopedModels,
+    generateRelationProperties: swaggerSpecExtensions.generateRelationProperties,
+  };
+
+  // Prevent insert configurations into swagger definitions
+  swaggerSpecExtensions = _.omit(swaggerSpecExtensions, [
+    'generateOperationScopedModels',
+    'generateRelationProperties',
+  ]);
+
+  opts = _.defaults(opts, swaggerOptions, {
     basePath: loopbackApplication.get('restApiRoot') || '/api',
     // Default consumes/produces
     consumes: [
@@ -44,14 +64,8 @@ module.exports = function createSwaggerObject(loopbackApplication, opts) {
     version: getPackagePropertyOrDefault('version', '1.0.0'),
   });
 
-  // We need a temporary REST adapter to discover our available routes.
-  var remotes = loopbackApplication.remotes();
-  var adapter = remotes.handler('rest').adapter;
-  var routes = adapter.allRoutes();
-  var classes = remotes.classes();
-
   // Generate fixed fields like info and basePath
-  var swaggerObject = generateSwaggerObjectBase(opts, loopbackApplication);
+  var swaggerObject = generateSwaggerObjectBase(opts, swaggerSpecExtensions);
 
   var typeRegistry = new TypeRegistry();
   var operationIdRegistry = Object.create(null);
@@ -107,10 +121,9 @@ module.exports = function createSwaggerObject(loopbackApplication, opts) {
  * Generate a top-level resource doc. This is the entry point for swagger UI
  * and lists all of the available APIs.
  * @param  {Object} opts Swagger options.
- * @return {Object}      Resource doc.
+ * @return {Object} swaggerSpecExtensions swagger spec extensions.
  */
-function generateSwaggerObjectBase(opts, loopbackApplication) {
-  var swaggerSpecExtensions = loopbackApplication.get('swagger');
+function generateSwaggerObjectBase(opts, swaggerSpecExtensions) {
   var apiInfo = _.cloneDeep(opts.apiInfo) || {};
   for (var propertyName in apiInfo) {
     var property = apiInfo[propertyName];
@@ -138,7 +151,7 @@ function generateSwaggerObjectBase(opts, loopbackApplication) {
     basePath: basePath,
     paths: {},
     tags: [],
-  }, swaggerSpecExtensions || {}, {
+  }, swaggerSpecExtensions, {
     host: opts.host,
     schemes: opts.protocol ? [opts.protocol] : undefined,
     consumes: opts.consumes,


### PR DESCRIPTION
### Description
Include relation properties when generating the swagger definition.
Is it possible to merge this PR without have a fork, and release a library under my organization?

#### Related issues

https://github.com/strongloop/loopback-swagger/issues/29

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
