### PR TITLE
chore: update copyright year

### DIFF
--- a/example/generator.js
+++ b/example/generator.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014,2017. All Rights Reserved.
+// Copyright IBM Corp. 2014,2019. All Rights Reserved.
 // Node module: loopback-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014,2017. All Rights Reserved.
+// Copyright IBM Corp. 2014,2019. All Rights Reserved.
 // Node module: loopback-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/codegen/generator-v1.2.js
+++ b/lib/codegen/generator-v1.2.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/codegen/model-template.js
+++ b/lib/codegen/model-template.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2017. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/codegen/spec-converter.js
+++ b/lib/codegen/spec-converter.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/specgen/model-helper.js
+++ b/lib/specgen/model-helper.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/specgen/schema-builder.js
+++ b/lib/specgen/schema-builder.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2017. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/specgen/swagger-spec-generator.js
+++ b/lib/specgen/swagger-spec-generator.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/specgen/tag-builder.js
+++ b/lib/specgen/tag-builder.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2017. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/specgen/type-registry.js
+++ b/lib/specgen/type-registry.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2017. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/specgen/fixtures/dummy-swagger-ui/swagger-ui.js
+++ b/test/specgen/fixtures/dummy-swagger-ui/swagger-ui.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/specgen/model-helper.test.js
+++ b/test/specgen/model-helper.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2017. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/specgen/route-helper.test.js
+++ b/test/specgen/route-helper.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/specgen/schema-builder.test.js
+++ b/test/specgen/schema-builder.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/specgen/swagger-spec-generator.test.js
+++ b/test/specgen/swagger-spec-generator.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/specgen/tag-builder.test.js
+++ b/test/specgen/tag-builder.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2017. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT


### PR DESCRIPTION
### Description
Related: strongloop-internal/scrum-apex#440

Update the copyrights year in the rest of the packages besides #4596.

The changes are introduced by running the `slt copyright` command. 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
