### PR TITLE
fix operational id to be underscore for openapi generators

### DIFF
--- a/lib/specgen/route-helper.js
+++ b/lib/specgen/route-helper.js
@@ -245,7 +245,8 @@ var routeHelper = module.exports = {
       tags.push(classDef.name);
     }
 
-    var operationId = createUniqueOperationId(route.method, verb, path,
+    var id = route.method.replace('.', '_');
+    var operationId = createUniqueOperationId(id, verb, path,
       operationIdRegistry);
     var entry = {
       path: path,


### PR DESCRIPTION
### Description
Currently the operationId in the generated swagger prefixes the method name with the class name (to make it unique) and separates it by a period (.).

The standard OpenAPI generator for typescript angular (and other generators) does not understand the period separator. It has an option to remove the prefix and it searches for an underscore (_).

This fix is to change the prefix to an underscore so the generators can pick it up.
### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
